### PR TITLE
Fix commands in tox as it is generating a lot of unrelated errors.

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,5 +9,5 @@ deps =
     pyflakes
 
 commands =
-    pep8 --config=.pep8rc .
+    pep8 --config=.pep8rc docs mozci scripts
     pyflakes docs mozci scripts


### PR DESCRIPTION
If I run tox without the below changes, I get this unrelated errors output: http://pastebin.mozilla.org/8784601
