### PR TITLE
Rename associated_build_job() to determine_upstream_builder()

### DIFF
--- a/mozci/mozci.py
+++ b/mozci/mozci.py
@@ -11,7 +11,7 @@ from __future__ import absolute_import
 import json
 import logging
 
-from mozci.platforms import associated_build_job, does_builder_need_files
+from mozci.platforms import determine_upstream_builder, does_builder_need_files
 from mozci.sources import allthethings, buildapi, buildjson, pushlog
 from mozci.utils.misc import _all_urls_reachable
 
@@ -44,7 +44,7 @@ def _determine_trigger_objective(repo_name, revision, buildername):
 
     # Let's figure out the associated build job
     # XXX: We have to handle the case when we query a build job
-    build_buildername = associated_build_job(buildername, repo_name)
+    build_buildername = determine_upstream_builder(buildername, repo_name)
     assert valid_builder(build_buildername), \
         "Our platforms mapping system has failed."
     # Let's figure out which jobs are associated to such revision

--- a/mozci/platforms.py
+++ b/mozci/platforms.py
@@ -6,8 +6,8 @@ to help us with this task.
 from sources.allthethings import fetch_allthethings_data
 
 # We will start by pre-computing some structures that will be used for
-# associated_build_job. They are globals so we don't compute them over
-# and over again when calling associated_build_job multiple times
+# determine_upstream_builder. They are globals so we don't compute them over
+# and over again when calling determine_upstream_builder multiple times
 
 all_builders_information = fetch_allthethings_data()
 buildernames = all_builders_information['builders'].keys()
@@ -78,7 +78,7 @@ for sched, values in all_builders_information['schedulers'].iteritems():
         buildername_to_trigger[buildername] = values['triggered_by'][0]
 
 
-def associated_build_job(buildername, repo_name):
+def determine_upstream_builder(buildername, repo_name):
     '''Given a builder name, find the build job that triggered it. When
     buildername corresponds to a test job, it does so by looking at
     allthethings.json. When buildername corresponds to a build job, it

--- a/test/test_platforms.py
+++ b/test/test_platforms.py
@@ -32,7 +32,7 @@ def complex_data():
 
     # The values of all the builds can be obtained by using .values()
     # on the data from test_platforms.json. When asking
-    # associated_build_job() for a builder we return itself. We add known
+    # determine_upstream_builder() for a builder we return itself. We add known
     # build jobs to reference_builders_info
     build_jobs = set(reference_builders_info.values())
     for build_job in build_jobs:
@@ -43,7 +43,7 @@ def complex_data():
     tests = []
     for builder in reference_builders_info.keys():
         properties = latest_builders[builder]['properties']
-        # If we can't guess a repo_name we can't test associated_build_jobs
+        # If we can't guess a repo_name we can't test determine_upstream_builder
         try:
             repo_name = properties['repo_path'].split('/')[-1]
         except:
@@ -65,6 +65,6 @@ list_untested()
 
 @pytest.mark.parametrize("builder,repo_name,expected", complex_data())
 def test_builders(builder, repo_name, expected):
-    obtained = mozci.platforms.associated_build_job(builder, repo_name)
+    obtained = mozci.platforms.determine_upstream_builder(builder, repo_name)
     assert obtained == expected, \
         'obtained: "%s", expected "%s"' % (obtained, expected)


### PR DESCRIPTION
This pull request fixes issue#34.
