### PR TITLE
trigger_range.py should make --times optional and assume a value of 1

### DIFF
--- a/scripts/trigger_range.py
+++ b/scripts/trigger_range.py
@@ -24,8 +24,8 @@ def parse_args(argv=None):
 
     parser.add_argument("--times",
                         dest="times",
-                        required=True,
                         type=int,
+                        default=1,
                         help="Number of times to retrigger the push.")
 
     parser.add_argument("--delta",


### PR DESCRIPTION
This fixes https://github.com/armenzg/mozilla_ci_tools/issues/60
