### PR TITLE
Added missing return statement to _fetch

### DIFF
--- a/mozci/sources/allthethings.py
+++ b/mozci/sources/allthethings.py
@@ -83,7 +83,7 @@ def fetch_allthethings_data(no_caching=False):
             return data
         else:
             LOG.debug('File integrity failed. Retrying fetching the file.')
-            _fetch()
+            return _fetch()
 
     def _verify_file_integrity():
         statinfo = os.stat(FILENAME)


### PR DESCRIPTION
_fetch was returning None when _verify_file_integrity was False, because we weren't propagating the result of retrying.
