### PR TITLE
Issue 101: Wrap code inside _process_data()

### DIFF
--- a/mozci/platforms.py
+++ b/mozci/platforms.py
@@ -6,17 +6,11 @@ import logging
 from sources.allthethings import fetch_allthethings_data
 
 LOG = logging.getLogger()
-# We will start by pre-computing some structures that will be used for
-# determine_upstream_builder. They are globals so we don't compute them over
-# and over again when calling determine_upstream_builder multiple times
-
-all_builders_information = fetch_allthethings_data()
-buildernames = all_builders_information['builders'].keys()
 
 
 def is_downstream(buildername):
     """Determine if a job requires files to be triggered."""
-    props = all_builders_information['builders'][buildername]['properties']
+    props = fetch_allthethings_data()['builders'][buildername]['properties']
     return 'slavebuilddir' in props and props['slavebuilddir'] == 'test'
 
 # In buildbot, once a build job finishes, it triggers a scheduler,
@@ -32,7 +26,7 @@ def is_downstream(buildername):
 #               { ...  "shortname": "larch-android-api-11", ...},
 # Will give us the entry:
 # "larch-android-api-11" : "Android armv7 API 11+ larch build"
-shortname_to_name = {}
+SHORTNAME_TO_NAME = {}
 
 # For every test job we can find the scheduler that runs it and the
 # corresponding trigger in allthethings.json. For example:
@@ -43,48 +37,53 @@ shortname_to_name = {}
 # means that "Android 4.0 armv7 API 11+ larch opt test cppunit" is ran
 # by the "tests-larch-panda_android-opt-unittest" scheduler, and this
 # scheduler is triggered by "larch-android-api-11-opt-unittest". In
-# buildername_to_trigger we'll store the corresponding trigger to
+# BUILDERNAME_TO_TRIGGER we'll store the corresponding trigger to
 # every test job. In this case, "Android 4.0 armv7 API 11+ larch opt
 # test cppunit" : larch-android-api-11-opt-unittest
-buildername_to_trigger = {}
+BUILDERNAME_TO_TRIGGER = {}
+BUILD_JOBS = {}
 
-# We'll look at every builder and if it's a build job we will add it
-# to shortname_to_name
-build_jobs = []
-for buildername in buildernames:
-    # Skipping nightly for now
-    if 'nightly' in buildername:
-        continue
 
-    builder_info = all_builders_information['builders'][buildername]
-    props = builder_info['properties']
-    # We heuristically figure out what jobs are build jobs by checking
-    # the "slavebuilddir" property
-    if not is_downstream(buildername):
-        shortname_to_name[builder_info['shortname']] = buildername
-        build_jobs.append(buildername)
+def _process_data():
+    """Filling the dictionaries used by determine_upstream_builder."""
+    # We check if we already computed before
+    if BUILDERNAME_TO_TRIGGER:
+        LOG.debug("Reusing builders' relations computed from allthethings data.")
+        return
 
-# data['schedulers'] is a dictionary that maps a scheduler name to a
-# dictionary of it's properties:
-# "schedulers": {...
-# "tests-larch-panda_android-opt-unittest": {
-#    "downstream": [ "Android 4.0 armv7 API 11+ larch opt test cppunit",
-#                    "Android 4.0 armv7 API 11+ larch opt test crashtest",
-#                    "Android 4.0 armv7 API 11+ larch opt test jsreftest-1",
-#                    "Android 4.0 armv7 API 11+ larch opt test jsreftest-2",
-#                    ... ],
-#    "triggered_by": ["larch-android-api-11-opt-unittest"]},
-# A test scheduler has a list of tests in "downstream" and a trigger
-# name in "triggered_by". We will map every test in downstream to the
-# trigger name in triggered_by
-for sched, values in all_builders_information['schedulers'].iteritems():
-    # We are only interested in test schedulers
-    if not sched.startswith('tests-'):
-        continue
+    LOG.debug("Computing builders' relations from allthethings data.")
+    # We'll look at every builder and if it's a build job we will add it
+    # to SHORTNAME_TO_NAME
+    for buildername, builderinfo in fetch_allthethings_data()['builders'].iteritems():
+        # Skipping nightly for now
+        if 'nightly' in buildername:
+            continue
 
-    for buildername in values['downstream']:
-        assert buildername not in buildername_to_trigger
-        buildername_to_trigger[buildername.lower()] = values['triggered_by'][0]
+        if not is_downstream(buildername):
+            SHORTNAME_TO_NAME[builderinfo['shortname']] = buildername
+            BUILD_JOBS[buildername.lower()] = buildername
+
+    # data['schedulers'] is a dictionary that maps a scheduler name to a
+    # dictionary of it's properties:
+    # "schedulers": {...
+    # "tests-larch-panda_android-opt-unittest": {
+    #    "downstream": [ "Android 4.0 armv7 API 11+ larch opt test cppunit",
+    #                    "Android 4.0 armv7 API 11+ larch opt test crashtest",
+    #                    "Android 4.0 armv7 API 11+ larch opt test jsreftest-1",
+    #                    "Android 4.0 armv7 API 11+ larch opt test jsreftest-2",
+    #                    ... ],
+    #    "triggered_by": ["larch-android-api-11-opt-unittest"]},
+    # A test scheduler has a list of tests in "downstream" and a trigger
+    # name in "triggered_by". We will map every test in downstream to the
+    # trigger name in triggered_by
+    for sched, values in fetch_allthethings_data()['schedulers'].iteritems():
+        # We are only interested in test schedulers
+        if not sched.startswith('tests-'):
+            continue
+
+        for buildername in values['downstream']:
+            assert buildername.lower() not in BUILDERNAME_TO_TRIGGER
+            BUILDERNAME_TO_TRIGGER[buildername.lower()] = values['triggered_by'][0]
 
 
 def determine_upstream_builder(buildername):
@@ -95,11 +94,11 @@ def determine_upstream_builder(buildername):
     triggering build job through allthethings.json. When a buildername
     corresponds to a build job, it returns it unchanged.
     """
-    # If a buildername is in build_jobs, it means that it's a build job
+    _process_data()
+    # If a buildername is in BUILD_JOBS, it means that it's a build job
     # and it should be returned unchanged
-    for build_job in build_jobs:
-        if build_job.lower() == buildername.lower():
-            return build_job
+    if buildername.lower() in BUILD_JOBS:
+        return BUILD_JOBS[buildername.lower()]
 
     # For some (but not all) platforms and repos, -pgo is explicit in
     # the trigger but not in the shortname, e.g. "Linux
@@ -110,28 +109,28 @@ def determine_upstream_builder(buildername):
 
     # Guess the build job's shortname from the test job's trigger
     # e.g. from "larch-android-api-11-opt-unittest"
-    # look for "larch-android-api-11" in shortname_to_name and find
+    # look for "larch-android-api-11" in SHORTNAME_TO_NAME and find
     # "Android armv7 API 11+ larch build"
-    if buildername.lower() not in buildername_to_trigger:
+    if buildername.lower() not in BUILDERNAME_TO_TRIGGER:
         LOG.error("We didn't find a build job matching %s" % buildername)
         raise Exception("No build job found.")
 
-    shortname = buildername_to_trigger[buildername.lower()]
+    shortname = BUILDERNAME_TO_TRIGGER[buildername.lower()]
     for suffix in SUFFIXES:
         if shortname.endswith(suffix):
             shortname = shortname[:-len(suffix)]
-            if shortname in shortname_to_name:
-                return shortname_to_name[shortname]
+            if shortname in SHORTNAME_TO_NAME:
+                return SHORTNAME_TO_NAME[shortname]
 
     # B2G jobs are weird
     shortname = "b2g_" + shortname.replace('-emulator', '_emulator') + "_dep"
-    if shortname in shortname_to_name:
-        return shortname_to_name[shortname]
+    if shortname in SHORTNAME_TO_NAME:
+        return SHORTNAME_TO_NAME[shortname]
 
 
 def get_associated_platform_name(buildername):
     """Given a buildername, find the platform in which it is ran."""
-    props = all_builders_information['builders'][buildername]['properties']
+    props = fetch_allthethings_data()['builders'][buildername]['properties']
     # For talos tests we have to check stage_platform
     if 'talos' in buildername:
         return props['stage_platform']

--- a/mozci/sources/allthethings.py
+++ b/mozci/sources/allthethings.py
@@ -58,6 +58,8 @@ FILENAME = "allthethings.json"
 ALLTHETHINGS = \
     "https://secure.pub.build.mozilla.org/builddata/reports/allthethings.json"
 
+DATA = None
+
 
 def fetch_allthethings_data(no_caching=False):
     """
@@ -69,6 +71,7 @@ def fetch_allthethings_data(no_caching=False):
         LOG.debug("Fetching allthethings.json %s" % ALLTHETHINGS)
         req = requests.get(ALLTHETHINGS, stream=True)
 
+        # This automatically erases the previous cached file.
         with open(FILENAME, "wb") as fd:
             for chunk in req.iter_content(chunk_size=1024):
                 if chunk:  # filter out keep-alive new chunks
@@ -84,6 +87,9 @@ def fetch_allthethings_data(no_caching=False):
             return _fetch()
 
     def _verify_file_integrity():
+        if not os.path.exists(FILENAME):
+            return False
+
         statinfo = os.stat(FILENAME)
         file_size = statinfo.st_size
         response = requests.head(ALLTHETHINGS)
@@ -93,21 +99,20 @@ def fetch_allthethings_data(no_caching=False):
         else:
             return True
 
-    if no_caching:
-        data = _fetch()
-    else:
-        if os.path.exists(FILENAME):
-            # If corrupt incomplete / old file, remove
-            if not _verify_file_integrity():
-                os.remove(FILENAME)
-                data = _fetch()
-            else:
-                fd = open(FILENAME)
-                data = json.load(fd)
-        else:
-            data = _fetch()
+    global DATA
 
-    return data
+    if no_caching:
+        DATA = _fetch()
+    # If we do not have an in-memory cache, try to use the file cache.
+    elif DATA is None:
+        # Only use the file cache if it is up-to-date and not corrupted.
+        if _verify_file_integrity():
+            fd = open(FILENAME)
+            DATA = json.load(fd)
+        else:
+            DATA = _fetch()
+
+    return DATA
 
 
 def list_builders():


### PR DESCRIPTION
I moved computing the dictionaries to the function _process_data(). Also, instead of using all_builders_information we are now just calling fetch_allthethings_data(). To avoid making things too slow I added some in-memory-caching to allthethings.py. The final result is actually faster then before this patch (py.test went from 16s to 7s on my machine)
