### PR TITLE
Added 'debug' and 'opt' keys to graph.json

### DIFF
--- a/mozci/platforms.py
+++ b/mozci/platforms.py
@@ -145,9 +145,9 @@ def _get_test(buildername):
     return buildername.split(" ")[-1]
 
 
-def filter_builders_matching(builders, keyword):
+def _filter_builders_matching(builders, keyword):
     """Find all the builders in a list that contain a keyword."""
-    return [builder for builder in builders if keyword in builder]
+    return filter(lambda x: keyword in x, builders)
 
 
 def build_tests_per_platform_graph(builders):
@@ -155,6 +155,7 @@ def build_tests_per_platform_graph(builders):
     graph = {'debug': {}, 'opt': {}}
 
     for builder in builders:
+        test = None
         if is_downstream(builder):
             # Some builders in allthethings (for example, "Android 2.3
             # Armv6 Emulator mozilla-esr31 opt test crashtest-1") are
@@ -167,19 +168,35 @@ def build_tests_per_platform_graph(builders):
                 continue
 
             test = _get_test(builder)
-            if platform.endswith('-debug'):
-                key = 'debug'
-                platform = platform[:-len('-debug')]
-            else:
-                key = 'opt'
 
-            if platform not in graph[key]:
-                graph[key][platform] = collections.defaultdict(list)
+        else:
+            platform = get_associated_platform_name(builder)
+            upstream = builder
 
+        if platform.endswith('-debug'):
+            key = 'debug'
+            platform = platform[:-len('-debug')]
+
+        else:
+            key = 'opt'
+
+        if platform not in graph[key]:
+            graph[key][platform] = collections.defaultdict(list)
+            graph[key][platform]['tests'] = []
+
+        # We need to add test jobs to their corresponding upstream
+        # builders key and test types to the list of tests that ran in
+        # that platform.
+        if test is not None:
             graph[key][platform][upstream].append(builder)
 
             if test not in graph[key][platform]['tests']:
                 graph[key][platform]['tests'].append(test)
+
+        # Even build jobs with no test jobs should be keys in the
+        # graph.
+        if upstream not in graph[key][platform]:
+            graph[key][platform][upstream] = []
 
     for key in graph:
         for platform in graph[key]:

--- a/scripts/misc/write_tests_per_platform_graph.py
+++ b/scripts/misc/write_tests_per_platform_graph.py
@@ -8,12 +8,6 @@ from mozci.sources.allthethings import fetch_allthethings_data
 
 if __name__ == '__main__':
     with open('graph.json', 'w') as f:
-        builders = filter_builders_matching(fetch_allthethings_data()['builders'], "")
+        builders = filter_builders_matching(fetch_allthethings_data()['builders'], " try ")
         graph = build_tests_per_platform_graph(builders)
-        print 'Debug platforms: '
-        for x in  sorted(graph['debug'].keys()):
-            print x + ', ',
-        print '\n Opt platforms:'
-        for x in  sorted(graph['opt'].keys()):
-            print x + ', ',
         json.dump(graph, f, sort_keys=True, indent=4, separators=(',', ': '))

--- a/scripts/misc/write_tests_per_platform_graph.py
+++ b/scripts/misc/write_tests_per_platform_graph.py
@@ -2,12 +2,12 @@
 
 import json
 
-from mozci.platforms import build_tests_per_platform_graph, filter_builders_matching
+from mozci.platforms import build_tests_per_platform_graph, _filter_builders_matching
 from mozci.sources.allthethings import fetch_allthethings_data
 
 
 if __name__ == '__main__':
     with open('graph.json', 'w') as f:
-        builders = filter_builders_matching(fetch_allthethings_data()['builders'], " try ")
+        builders = _filter_builders_matching(fetch_allthethings_data()['builders'], " try ")
         graph = build_tests_per_platform_graph(builders)
         json.dump(graph, f, sort_keys=True, indent=4, separators=(',', ': '))

--- a/scripts/misc/write_tests_per_platform_graph.py
+++ b/scripts/misc/write_tests_per_platform_graph.py
@@ -2,12 +2,18 @@
 
 import json
 
-from mozci.platforms import build_tests_per_platform_graph
+from mozci.platforms import build_tests_per_platform_graph, filter_builders_matching
 from mozci.sources.allthethings import fetch_allthethings_data
 
 
 if __name__ == '__main__':
     with open('graph.json', 'w') as f:
-        builders = fetch_allthethings_data()['builders']
+        builders = filter_builders_matching(fetch_allthethings_data()['builders'], "")
         graph = build_tests_per_platform_graph(builders)
+        print 'Debug platforms: '
+        for x in  sorted(graph['debug'].keys()):
+            print x + ', ',
+        print '\n Opt platforms:'
+        for x in  sorted(graph['opt'].keys()):
+            print x + ', ',
         json.dump(graph, f, sort_keys=True, indent=4, separators=(',', ': '))

--- a/test/test_platforms.py
+++ b/test/test_platforms.py
@@ -117,8 +117,10 @@ def test_get_associated_platform_name(builder, expected):
 
 def test_build_tests_per_platform_graph():
     """Test that build_tests_per_platform_graph correctly maps platforms to tests."""
-    BUILDERS = ["Ubuntu HW 12.04 mozilla-aurora talos svgr"]
+    BUILDERS = ["Ubuntu HW 12.04 mozilla-aurora talos svgr",
+                "Ubuntu VM 12.04 b2g-inbound debug test xpcshell"]
     obtained = mozci.platforms.build_tests_per_platform_graph(BUILDERS)
-    expected = {"linux": ["svgr"]}
+    expected = {"debug": {"linux": ["xpcshell"]},
+                "opt": {"linux": ["svgr"]}}
     assert obtained == expected, \
         'obtained: "%s", expected "%s"' % (obtained, expected)

--- a/test/test_platforms.py
+++ b/test/test_platforms.py
@@ -120,7 +120,24 @@ def test_build_tests_per_platform_graph():
     BUILDERS = ["Ubuntu HW 12.04 mozilla-aurora talos svgr",
                 "Ubuntu VM 12.04 b2g-inbound debug test xpcshell"]
     obtained = mozci.platforms.build_tests_per_platform_graph(BUILDERS)
-    expected = {"debug": {"linux": ["xpcshell"]},
-                "opt": {"linux": ["svgr"]}}
+    expected = {'debug': {'linux':
+                          {'tests': ['xpcshell'],
+                           'Linux b2g-inbound leak test build':
+                           ['Ubuntu VM 12.04 b2g-inbound debug test xpcshell']}},
+                'opt': {'linux':
+                        {'tests': ['svgr'],
+                         'Linux mozilla-aurora build':
+                         ['Ubuntu HW 12.04 mozilla-aurora talos svgr']}}}
+
+    assert obtained == expected, \
+        'obtained: "%s", expected "%s"' % (obtained, expected)
+
+
+def test_filter_builders_matching():
+    """Test that filter_builders_matching correctly filters builds."""
+    BUILDERS = ["Ubuntu HW 12.04 mozilla-aurora talos svgr",
+                "Ubuntu VM 12.04 b2g-inbound debug test xpcshell"]
+    obtained = mozci.platforms.filter_builders_matching(BUILDERS, " talos ")
+    expected = ["Ubuntu HW 12.04 mozilla-aurora talos svgr"]
     assert obtained == expected, \
         'obtained: "%s", expected "%s"' % (obtained, expected)

--- a/test/test_platforms.py
+++ b/test/test_platforms.py
@@ -134,10 +134,10 @@ def test_build_tests_per_platform_graph():
 
 
 def test_filter_builders_matching():
-    """Test that filter_builders_matching correctly filters builds."""
+    """Test that _filter_builders_matching correctly filters builds."""
     BUILDERS = ["Ubuntu HW 12.04 mozilla-aurora talos svgr",
                 "Ubuntu VM 12.04 b2g-inbound debug test xpcshell"]
-    obtained = mozci.platforms.filter_builders_matching(BUILDERS, " talos ")
+    obtained = mozci.platforms._filter_builders_matching(BUILDERS, " talos ")
     expected = ["Ubuntu HW 12.04 mozilla-aurora talos svgr"]
     assert obtained == expected, \
         'obtained: "%s", expected "%s"' % (obtained, expected)


### PR DESCRIPTION
We now have to main keys: 'opt' and 'debug', each key contains it's own dictionary of platforms and tests. The new output is: https://pastebin.mozilla.org/8825005

Writing this patch I discovered that some test jobs in allthethings.json have no upstream builders. Originally I thought it was a bug in platforms.py, but I inspected they manually in Treeherder and found out they really did not have upstream builders (like b2g_ubuntu64_vm gaia-try opt test gaia-js-integration-7 and Android 4.0 Panda mozilla-esr31 opt test mochitest-6).
