### PR TITLE
Fixing TypeError in generate_triggercli.py

### DIFF
--- a/scripts/generate_triggercli.py
+++ b/scripts/generate_triggercli.py
@@ -125,8 +125,8 @@ def generate_cli(search_dict, back_revisions, times=20):
     for bname, rev in search_dict.iteritems():
         check_repository(bname)
         # Using print instead of logging to make it easier to copy/paste
-        print "python %s/trigger.py " + \
-              "--rev=%s --back-revisions=%s --buildername='%s' " + \
+        print "python %s/trigger.py " \
+              "--rev=%s --back-revisions=%s --buildername='%s' " \
               "--times=%s --dry-run" % (os.getcwd(), rev, back_revisions, bname, times)
 
 


### PR DESCRIPTION
Getting this TypeError:

Traceback (most recent call last):
  File "generate_triggercli.py", line 176, in <module>
    main()
  File "generate_triggercli.py", line 70, in main
    generate_cli(search_dict, options.back_revisions, options.times)
  File "generate_triggercli.py", line 130, in generate_cli
    "--times=%s --dry-run" % (os.getcwd(), rev, back_revisions, bname, times)
TypeError: not all arguments converted during string formatting

This patch fixes this.
