### PR TITLE
Issue 125: Saving files in .mozilla/mozci/

### DIFF
--- a/mozci/mozci.py
+++ b/mozci/mozci.py
@@ -17,6 +17,7 @@ import logging
 from mozci.platforms import determine_upstream_builder, is_downstream
 from mozci.sources import allthethings, buildapi, buildjson, pushlog
 from mozci.utils.misc import _all_urls_reachable
+from mozci.utils.transfer import path_to_file
 
 LOG = logging.getLogger()
 SCHEDULING_MANAGER = {}
@@ -296,7 +297,7 @@ def valid_builder(buildername):
         LOG.warning("Buildername %s is *NOT* valid." % buildername)
         LOG.info("Check the file we just created builders.txt for "
                  "a list of valid builders.")
-        with open("builders.txt", "wb") as fd:
+        with open(path_to_file('builders.txt'), "wb") as fd:
             for b in sorted(builders):
                 fd.write(b + "\n")
 

--- a/mozci/sources/allthethings.py
+++ b/mozci/sources/allthethings.py
@@ -52,9 +52,11 @@ import os
 
 import requests
 
+from mozci.utils.transfer import path_to_file
+
 LOG = logging.getLogger()
 
-FILENAME = "allthethings.json"
+FILENAME = path_to_file("allthethings.json")
 ALLTHETHINGS = \
     "https://secure.pub.build.mozilla.org/builddata/reports/allthethings.json"
 

--- a/mozci/sources/buildapi.py
+++ b/mozci/sources/buildapi.py
@@ -18,10 +18,11 @@ import requests
 
 from mozci.utils.authentication import get_credentials
 from mozci.sources.buildjson import query_job_data
+from mozci.utils.transfer import path_to_file
 
 LOG = logging.getLogger()
 HOST_ROOT = 'https://secure.pub.build.mozilla.org/buildapi/self-serve'
-REPOSITORIES_FILE = os.path.abspath("repositories.txt")
+REPOSITORIES_FILE = path_to_file("repositories.txt")
 REPOSITORIES = {}
 
 # Self-serve cannot give us the whole granularity of states; Use buildjson where necessary.

--- a/mozci/sources/buildjson.py
+++ b/mozci/sources/buildjson.py
@@ -7,7 +7,7 @@ import json
 import logging
 
 from mozci.utils.tzone import utc_dt, utc_time, utc_day
-from mozci.utils.transfer import fetch_file
+from mozci.utils.transfer import fetch_file, path_to_file
 
 LOG = logging.getLogger()
 
@@ -20,25 +20,26 @@ BUILDS_DAY_INDEX = {}
 
 
 def _fetch_file(filename):
-    '''
+    """
     Helper method to download files.
 
     This function caches the uncompressed gzip files requested in the past.
 
     Returns all jobs inside of this buildjson file.
-    '''
+    """
     url = "%s/%s.gz" % (BUILDJSON_DATA, filename)
     # If the file exists and is valid we won't download it again
     fetch_file(filename, url)
 
     LOG.debug("About to load %s." % filename)
-    builds = json.load(open(filename))["builds"]
+    builds = json.load(open(path_to_file(filename)))["builds"]
     return builds
 
 
 def _find_job(request_id, jobs, loaded_from):
     """
     Look for request_id in a list of jobs.
+
     loaded_from is simply to indicate where those jobs were loaded from.
     """
     found = None

--- a/mozci/utils/transfer.py
+++ b/mozci/utils/transfer.py
@@ -7,13 +7,20 @@ import requests
 LOG = logging.getLogger()
 
 
+def path_to_file(filename):
+    """Add files to .mozilla/mozci"""
+    path = os.path.expanduser('~/.mozilla/mozci/')
+    if not os.path.exists(path):
+        os.makedirs(path)
+    filepath = os.path.join(path, filename)
+    return filepath
+
+
 def _save_file(req, filename):
     # NOTE: requests deals with decompressing the gzip file
-    '''
-    Helper private function to simply save a file.
-    '''
+    """Helper private function to simply save a file."""
     LOG.debug("About to fetch %s from %s" % (filename, req.url))
-    with open(filename, 'wb') as fd:
+    with open(path_to_file(filename), 'wb') as fd:
         for chunk in req.iter_content(chunk_size=1024):
             if chunk:  # filter out keep-alive new chunks
                 fd.write(chunk)
@@ -21,10 +28,11 @@ def _save_file(req, filename):
 
 
 def fetch_file(filename, url):
-    '''
+    """
     We download a file and use streaming to improve the chances of success.
+
     We also check if the file on the server is newer or not to determine if we should download it.
-    '''
+    """
     if os.path.exists(filename):
         statinfo = os.stat(filename)
         last_mod_date = time.strftime('%a, %d %b %Y %H:%M:%S GMT', time.gmtime(statinfo.st_mtime))

--- a/scripts/misc/write_tests_per_platform_graph.py
+++ b/scripts/misc/write_tests_per_platform_graph.py
@@ -4,10 +4,11 @@ import json
 
 from mozci.platforms import build_tests_per_platform_graph, _filter_builders_matching
 from mozci.sources.allthethings import fetch_allthethings_data
+from mozci.utils.transfer import path_to_file
 
 
 if __name__ == '__main__':
-    with open('graph.json', 'w') as f:
+    with open(path_to_file('graph.json'), 'w') as f:
         builders = _filter_builders_matching(fetch_allthethings_data()['builders'], " try ")
         graph = build_tests_per_platform_graph(builders)
         json.dump(graph, f, sort_keys=True, indent=4, separators=(',', ': '))


### PR DESCRIPTION
I added a function organize_files to mozci/utils/transfer.py that adds ~/.mozilla/mozci to every file path. I tried using it every time we save a file, maybe I missed something. After running the script once I get:

alice@toshibinha:~/.mozilla/mozci$ ls
allthethings.json  builds-2015-02-26.js  graph.json  repositories.txt
