### PR TITLE
Fixed assertion, added spaces to find_buildernames

### DIFF
--- a/mozci/platforms.py
+++ b/mozci/platforms.py
@@ -162,7 +162,7 @@ def _get_test(buildername):
 
 def _filter_builders_matching(builders, keyword):
     """Find all the builders in a list that contain a keyword."""
-    return filter(lambda x: keyword in x, builders)
+    return map(str, filter(lambda x: keyword in x, builders))
 
 
 def build_tests_per_platform_graph(builders):

--- a/mozci/platforms.py
+++ b/mozci/platforms.py
@@ -267,11 +267,11 @@ def find_buildernames(repo, test=None, platform=None):
     2) if the developer provides test and platform only, then return the test on all platforms
     3) if the developer provides platform and repo, then return all the tests on that platform
     """
-    if test is None and platform is None:
-        assert False, 'test and platform cannot both be None.'
+    assert test is not None or platform is not None, 'test and platform cannot both be None.'
 
     matching = []
-    buildernames = _filter_builders_matching(fetch_allthethings_data()['builders'].keys(), repo)
+    buildernames = _filter_builders_matching(fetch_allthethings_data()['builders'].keys(),
+                                             ' %s ' % repo)
 
     if test is not None:
         buildernames = _filter_builders_matching(buildernames, test)


### PR DESCRIPTION
I misunderstood a previous comment about adding an assertion and ended up merging something wrong. This fixes it.

I also added spaces around repo to avoid false positives (so we don't get e.g. gaia-try builds when looking for try builds)
