### PR TITLE
Fixing PR 169

### DIFF
--- a/mozci/platforms.py
+++ b/mozci/platforms.py
@@ -259,7 +259,7 @@ def build_talos_buildernames_for_repo(repo_name, pgo_only=False):
     return retVal
 
 
-def find_buildernames(repo, test=None, platform=None):
+def find_buildernames(repo, test=None, platform=None, debug=False):
     """
     Return a list of buildernames matching the criteria.
 
@@ -275,6 +275,12 @@ def find_buildernames(repo, test=None, platform=None):
 
     if test is not None:
         buildernames = _filter_builders_matching(buildernames, test)
+
+    if debug:
+        buildernames = _filter_builders_matching(buildernames, ' debug ')
+
+    else:
+        buildernames = filter(lambda x: ' debug ' not in x, buildernames)
 
     if platform is not None:
         for buildername in buildernames:

--- a/mozci/platforms.py
+++ b/mozci/platforms.py
@@ -162,7 +162,7 @@ def _get_test(buildername):
 
 def _filter_builders_matching(builders, keyword):
     """Find all the builders in a list that contain a keyword."""
-    return filter(lambda x: keyword in x, builders)
+    return map(str, filter(lambda x: keyword in x, builders))
 
 
 def build_tests_per_platform_graph(builders):

--- a/mozci/platforms.py
+++ b/mozci/platforms.py
@@ -267,11 +267,11 @@ def find_buildernames(repo, test=None, platform=None):
     2) if the developer provides test and platform only, then return the test on all platforms
     3) if the developer provides platform and repo, then return all the tests on that platform
     """
-    if test is None and platform is None:
-        assert False, 'test and platform cannot both be None.'
+    assert test is not None or platform is not None, 'test and platform cannot both be None.'
 
     matching = []
-    buildernames = _filter_builders_matching(fetch_allthethings_data()['builders'].keys(), repo)
+    buildernames = _filter_builders_matching(fetch_allthethings_data()['builders'].keys(),
+                                             ' %s ' % repo)
 
     if test is not None:
         buildernames = _filter_builders_matching(buildernames, test)

--- a/test/mock_allthethings.json
+++ b/test/mock_allthethings.json
@@ -16,7 +16,7 @@
     "Platform1 repo debug test mochitest-1": {
         "properties": {
             "branch": "repo",
-            "platform": "platform1-debug",
+            "platform": "platform1",
             "product": "real-product",
             "repo_path": "real-path",
             "script_repo_revision": "production",

--- a/test/test_platforms.py
+++ b/test/test_platforms.py
@@ -40,6 +40,7 @@ class TestIsDownstream(unittest.TestCase):
 class TestFindBuildernames(unittest.TestCase):
 
     """Test find_buildernames with mock data."""
+
     @patch('mozci.platforms.fetch_allthethings_data')
     def test_full(self, fetch_allthethings_data):
         """The function should return a list with the specific buildername."""
@@ -47,6 +48,14 @@ class TestFindBuildernames(unittest.TestCase):
         self.assertEquals(
             mozci.platforms.find_buildernames('repo', platform='platform1', test='mochitest-1'),
             ['Platform1 repo mochitest-1'])
+
+    @patch('mozci.platforms.fetch_allthethings_data')
+    def test_with_debug(self, fetch_allthethings_data):
+        """The function should return a list with the specific debug buildername."""
+        fetch_allthethings_data.return_value = MOCK_ALLTHETHINGS
+        self.assertEquals(
+            mozci.platforms.find_buildernames('repo', platform='platform1', test='mochitest-1', debug=True),
+            ['Platform1 repo debug test mochitest-1'])
 
     @patch('mozci.platforms.fetch_allthethings_data')
     def test_without_platform(self, fetch_allthethings_data):


### PR DESCRIPTION
Turns out that only looking at the platform name does not tell us if a build is debug or not (test jobs do not have -debug in their 'platform' field, only build jobs do):

> > > from mozci.platforms import find_buildernames
> > > find_buildernames('try', 'mochitest-1', 'macosx64')
> > > ['Rev5 MacOSX Yosemite 10.10 try debug test mochitest-1',
> > > 'Rev5 MacOSX Mountain Lion 10.8 try opt test mochitest-1',
> > > 'Rev4 MacOSX Snow Leopard 10.6 try opt test mochitest-1',
> > > 'Rev4 MacOSX Snow Leopard 10.6 try debug test mochitest-1',
> > > 'Rev5 MacOSX Mountain Lion 10.8 try debug test mochitest-1',
> > > 'Rev5 MacOSX Yosemite 10.10 try opt test mochitest-1']
> > > find_buildernames('try', platform='macosx64-debug', test='mochitest-1')
> > > []

I fixed this by checking if ' debug ' is in the buildername. I believe that debug test jobs always have 'debug' in their names. Now we have:

> > > from mozci.platforms import find_buildernames
> > > find_buildernames('try', 'mochitest-1', 'macosx64')
> > > ['Rev5 MacOSX Mountain Lion 10.8 try opt test mochitest-1',
> > > 'Rev4 MacOSX Snow Leopard 10.6 try opt test mochitest-1',
> > > 'Rev5 MacOSX Yosemite 10.10 try opt test mochitest-1']
> > > find_buildernames('try', 'mochitest-1', 'macosx64', debug=True)
> > > ['Rev5 MacOSX Yosemite 10.10 try debug test mochitest-1',
> > > 'Rev4 MacOSX Snow Leopard 10.6 try debug test mochitest-1',
> > > 'Rev5 MacOSX Mountain Lion 10.8 try debug test mochitest-1']

PS.: I accidentally pressed 'close' on my previous PR (#173) and github does not let me restore it, so I'm making a new one. Sorry! 
