### PR TITLE
Add a way to filter out android/desktop and/or specific talos jobs

### DIFF
--- a/mozci/scripts/alltalos.py
+++ b/mozci/scripts/alltalos.py
@@ -49,6 +49,17 @@ def parse_args(argv=None):
                         dest="pgo",
                         help="trigger pgo tests (not non-pgo).")
 
+    parser.add_argument("--filter",
+                        action="store",
+                        dest="filterstring",
+                        help="comma-separated substring filter indicating which jobs to retrigger")
+
+    parser.add_argument("--platform",
+                        action="store",
+                        default="all",
+                        choices=["desktop", "android", "all"],
+                        help="indicate which platform to run jobs for (default: all)")
+
     options = parser.parse_args(argv)
     return options
 
@@ -71,7 +82,35 @@ def main():
 
     buildernames = build_talos_buildernames_for_repo(options.repo_name, pgo)
 
+    jobfilters = None
+    if options.filterstring:
+        jobfilters = options.filterstring.split(',')
+
     for buildername in buildernames:
+        try:
+            buildername.index("ndroid")
+            # This is an android build; if we only want desktop, ignore:
+            if options.platform == "desktop":
+                continue
+        except:
+            # This is a desktop build; if we only want android, ignore:
+            if options.platform == "android":
+                continue
+
+        if jobfilters:
+            shouldrun = False
+            for jobfilter in jobfilters:
+                try:
+                    buildername.index(jobfilter)
+                    shouldrun = True
+                    break
+                except:
+                    pass
+
+            if not shouldrun:
+                LOG.info("Not triggering " + buildername + " due to filter.")
+                continue
+
         trigger_job(revision=options.revision,
                     buildername=buildername,
                     times=options.times,


### PR DESCRIPTION
I needed to do this for my perf analysis and I felt bad retriggering all these suites/platforms I didn't need.
