### PR TITLE
fix missing return in mozci.utils.transfer.load_file

### DIFF
--- a/mozci/utils/transfer.py
+++ b/mozci/utils/transfer.py
@@ -137,7 +137,7 @@ def load_file(filename, url):
         elif req.status_code == 304:
             # The file on disk is recent
             LOG.debug("%s is on disk and it is current." % last_mod_date)
-            _load_json_file(filepath)
+            return _load_json_file(filepath)
         else:
             raise Exception("We received %s which is unexpected." % req.status_code)
     else:


### PR DESCRIPTION
It seems that mozci 0.6.0 is broken for me - I got the following error when trying to trigger a build:
Traceback (most recent call last):
  File "/home/jp/dev/mozbattue/venv/bin/mozbattue", line 9, in <module>
    load_entry_point('mozbattue==0.1', 'console_scripts', 'mozbattue')()
  File "/home/jp/dev/mozbattue/mozbattue/main.py", line 251, in main
    opts.func(opts)
  File "/home/jp/dev/mozbattue/mozbattue/main.py", line 119, in do_trigger
    times=opts.times, dry_run=opts.dry_run)
  File "/home/jp/dev/mozbattue/mozbattue/trigger.py", line 37, in trigger_jobs
    trigger_job(revision, buildername, times=times, dry_run=dry_run)
  File "/home/jp/dev/mozbattue/venv/lib/python2.7/site-packages/mozci/mozci.py", line 344, in trigger_job
    buildername,
  File "/home/jp/dev/mozbattue/venv/lib/python2.7/site-packages/mozci/mozci.py", line 121, in _determine_trigger_objective
    status = buildapi.query_job_status(job)
  File "/home/jp/dev/mozbattue/venv/lib/python2.7/site-packages/mozci/sources/buildapi.py", line 153, in query_job_status
    req["request_id"])
  File "/home/jp/dev/mozbattue/venv/lib/python2.7/site-packages/mozci/sources/buildjson.py", line 158, in query_job_data
    jobs = _fetch_data(filename)
  File "/home/jp/dev/mozbattue/venv/lib/python2.7/site-packages/mozci/sources/buildjson.py", line 44, in _fetch_data
    return json_contents["builds"]
TypeError: 'NoneType' object has no attribute '__getitem__'

It seems that I can trigger well this this patch.
