### PR TITLE
Fixed query_repo_name_from_buildername wrongly matching branchs

### DIFF
--- a/mozci/mozci.py
+++ b/mozci/mozci.py
@@ -246,7 +246,7 @@ def query_repo_name_from_buildername(buildername, clobber=False):
     repositories = buildapi.query_repositories(clobber)
     ret_val = None
     for repo_name in repositories:
-        if repo_name in buildername:
+        if (' %s ' % repo_name) in buildername:
             ret_val = repo_name
             break
 


### PR DESCRIPTION
I noticed sooner that: 

> > > query_repo_name_from_buildername('Linux try build')
> > > u'ux'

This patch fixes that:

> > > query_repo_name_from_buildername('Linux try build')
> > > u'try'
