### PR TITLE
Caching jobs

### DIFF
--- a/mozci/mozci.py
+++ b/mozci/mozci.py
@@ -21,7 +21,7 @@ from mozci.utils.transfer import path_to_file
 
 LOG = logging.getLogger('mozci')
 SCHEDULING_MANAGER = {}
-
+JOBS_CACHE = {}
 
 def _matching_jobs(buildername, all_jobs):
     """Return all jobs that matched the criteria."""
@@ -215,7 +215,10 @@ def _find_files(job_schedule_info):
 #
 def query_jobs(repo_name, revision):
     """Return list of jobs scheduling information for a revision."""
-    return buildapi.query_jobs_schedule(repo_name, revision)
+    global JOBS_CACHE
+    if (repo_name, revision) not in in JOBS_CACHE:
+        JOBS_CACHE[(repo_name, revision)] = buildapi.query_jobs_schedule(repo_name, revision)
+    return JOBS_CACHE[(repo_name, revision)]
 
 
 def query_jobs_buildername(buildername, revision):

--- a/mozci/mozci.py
+++ b/mozci/mozci.py
@@ -216,7 +216,12 @@ def _find_files(job_schedule_info):
 def query_jobs(repo_name, revision):
     """Return list of jobs scheduling information for a revision."""
     global JOBS_CACHE
-    if (repo_name, revision) not in in JOBS_CACHE:
+    if (repo_name, revision) not in JOBS_CACHE:
+        # We currently have 2 use cases with multiple jobs: triggering
+        # several jobs in one revision or triggering the same job in
+        # different revsions. Caching query_jobs is only useful for
+        # the first case, and for that we only need to cache one job
+        JOBS_CACHE = {}
         JOBS_CACHE[(repo_name, revision)] = buildapi.query_jobs_schedule(repo_name, revision)
     return JOBS_CACHE[(repo_name, revision)]
 

--- a/mozci/mozci.py
+++ b/mozci/mozci.py
@@ -21,7 +21,6 @@ from mozci.utils.transfer import path_to_file
 
 LOG = logging.getLogger('mozci')
 SCHEDULING_MANAGER = {}
-JOBS_CACHE = {}
 
 
 def _matching_jobs(buildername, all_jobs):
@@ -216,14 +215,7 @@ def _find_files(job_schedule_info):
 #
 def query_jobs(repo_name, revision):
     """Return list of jobs scheduling information for a revision."""
-    global JOBS_CACHE
-    if (repo_name, revision) not in JOBS_CACHE:
-        # We currently have 2 use cases with multiple jobs: triggering
-        # several jobs in one revision or triggering the same job in
-        # different revisions. Caching query_jobs is only useful for
-        # the first case, and for that we only need to cache one job
-        JOBS_CACHE = {(repo_name, revision): buildapi.query_jobs_schedule(repo_name, revision)}
-    return JOBS_CACHE[(repo_name, revision)]
+    return buildapi.query_jobs_schedule(repo_name, revision)
 
 
 def query_jobs_buildername(buildername, revision):

--- a/mozci/mozci.py
+++ b/mozci/mozci.py
@@ -23,6 +23,7 @@ LOG = logging.getLogger('mozci')
 SCHEDULING_MANAGER = {}
 JOBS_CACHE = {}
 
+
 def _matching_jobs(buildername, all_jobs):
     """Return all jobs that matched the criteria."""
     LOG.debug("Find jobs matching '%s'" % buildername)
@@ -219,10 +220,9 @@ def query_jobs(repo_name, revision):
     if (repo_name, revision) not in JOBS_CACHE:
         # We currently have 2 use cases with multiple jobs: triggering
         # several jobs in one revision or triggering the same job in
-        # different revsions. Caching query_jobs is only useful for
+        # different revisions. Caching query_jobs is only useful for
         # the first case, and for that we only need to cache one job
-        JOBS_CACHE = {}
-        JOBS_CACHE[(repo_name, revision)] = buildapi.query_jobs_schedule(repo_name, revision)
+        JOBS_CACHE = {(repo_name, revision): buildapi.query_jobs_schedule(repo_name, revision)}
     return JOBS_CACHE[(repo_name, revision)]
 
 

--- a/mozci/sources/buildapi.py
+++ b/mozci/sources/buildapi.py
@@ -24,6 +24,7 @@ LOG = logging.getLogger('mozci')
 HOST_ROOT = 'https://secure.pub.build.mozilla.org/buildapi/self-serve'
 REPOSITORIES_FILE = path_to_file("repositories.txt")
 REPOSITORIES = {}
+VALID_CACHE = {}
 
 # Self-serve cannot give us the whole granularity of states; Use buildjson where necessary.
 # http://hg.mozilla.org/build/buildbot/file/0e02f6f310b4/master/buildbot/status/builder.py#l25
@@ -114,6 +115,11 @@ def valid_revision(repo_name, revision):
     There are revisions that won't exist in buildapi.
     This happens on pushes that do not have any jobs scheduled for them.
     """
+
+    global VALID_CACHE
+    if (repo_name, revision) in VALID_CACHE:
+        return VALID_CACHE[(repo_name, revision)]
+
     LOG.debug("Determine if the revision is valid in buildapi.")
     url = "%s/%s/rev/%s?format=json" % (HOST_ROOT, repo_name, revision)
     req = requests.get(url, auth=get_credentials())
@@ -122,13 +128,15 @@ def valid_revision(repo_name, revision):
         exit(1)
 
     content = json.loads(req.content)
+    ret = True
     if isinstance(content, dict):
         failure_message = "Revision %s not found on branch %s" % (revision, repo_name)
         if content["msg"] == failure_message:
             LOG.warning(failure_message)
-            return False
-    else:
-        return True
+        ret = False
+
+    VALID_CACHE[(repo_name, revision)] = ret
+    return ret
 
 
 #

--- a/mozci/sources/buildapi.py
+++ b/mozci/sources/buildapi.py
@@ -25,6 +25,7 @@ HOST_ROOT = 'https://secure.pub.build.mozilla.org/buildapi/self-serve'
 REPOSITORIES_FILE = path_to_file("repositories.txt")
 REPOSITORIES = {}
 VALID_CACHE = {}
+JOBS_CACHE = {}
 
 # Self-serve cannot give us the whole granularity of states; Use buildjson where necessary.
 # http://hg.mozilla.org/build/buildbot/file/0e02f6f310b4/master/buildbot/status/builder.py#l25
@@ -179,6 +180,10 @@ def query_jobs_schedule(repo_name, revision):
 
     raises BuildapiException
     """
+    global JOBS_CACHE
+    if (repo_name, revision) in JOBS_CACHE:
+        return JOBS_CACHE[(repo_name, revision)]
+
     if not valid_revision(repo_name, revision):
         raise BuildapiException
 
@@ -187,7 +192,8 @@ def query_jobs_schedule(repo_name, revision):
     req = requests.get(url, auth=get_credentials())
     assert req.status_code in [200], req.content
 
-    return req.json()
+    JOBS_CACHE[(repo_name, revision)] = req.json()
+    return JOBS_CACHE[(repo_name, revision)]
 
 
 def query_jobs_url(repo_name, revision):


### PR DESCRIPTION
"python mozci/scripts/triggerbyfilters.py try 443657964b30 -i 'mochitest-1' -e android,b2g,pgo,10.8,coverage,asan --dry-run --times 7"
takes 26 seconds in this branch (versus 131 seconds in master)

I believe this change is worth merging.
