### PR TITLE
Issue #121: added --trigger-build-if-missing flag to alltalos.py

### DIFF
--- a/mozci/mozci.py
+++ b/mozci/mozci.py
@@ -48,9 +48,9 @@ def _unique_build_request(buildername, revision):
         return True
     else:
         if revision in sch_mgr and buildername in sch_mgr[revision]:
-            LOG.info("We have already scheduled the build '%s' for "
-                     "revision %s during this session. We don't allow "
-                     "multiple requests." % (buildername, revision))
+            LOG.debug("We have already scheduled the build '%s' for "
+                      "revision %s during this session. We don't allow "
+                      "multiple requests." % (buildername, revision))
             return False
         return True
 
@@ -77,7 +77,7 @@ def _status_summary(jobs):
     return (successful, pending, running, coalesced)
 
 
-def _determine_trigger_objective(revision, buildername, existing_only=False):
+def _determine_trigger_objective(revision, buildername, trigger_build_if_missing=True):
     """
     Determine if we need to trigger any jobs and which job.
 
@@ -159,7 +159,7 @@ def _determine_trigger_objective(revision, buildername, existing_only=False):
     else:
         # We were trying to build a test job, however, we determined
         # that we need an upstream builder instead
-        if existing_only or not _unique_build_request(build_buildername, revision):
+        if not trigger_build_if_missing or not _unique_build_request(build_buildername, revision):
             # This is a safeguard to prevent triggering a build
             # job multiple times if it is not intentional
             builder_to_trigger = None
@@ -319,7 +319,7 @@ def valid_builder(buildername):
 # Trigger functionality
 #
 def trigger_job(revision, buildername, times=1, files=None, dry_run=False,
-                extra_properties=None, existing_only=False):
+                extra_properties=None, trigger_build_if_missing=True):
     """Trigger a job through self-serve.
 
     We return a list of all requests made.
@@ -345,7 +345,7 @@ def trigger_job(revision, buildername, times=1, files=None, dry_run=False,
         builder_to_trigger, files = _determine_trigger_objective(
             revision,
             buildername,
-            existing_only
+            trigger_build_if_missing
         )
 
         if builder_to_trigger != buildername and times != 1:
@@ -355,7 +355,7 @@ def trigger_job(revision, buildername, times=1, files=None, dry_run=False,
             # we only trigger the upstream jobs once.
             LOG.debug("Since we need to trigger a build job we don't need to "
                       "trigger it %s times but only once." % times)
-            if not existing_only:
+            if trigger_build_if_missing:
                 LOG.info("In order to trigger %s %i times, please run the script again after %s ends."
                          % (buildername, times, builder_to_trigger))
             else:

--- a/mozci/mozci.py
+++ b/mozci/mozci.py
@@ -324,7 +324,7 @@ def valid_builder(buildername):
 # Trigger functionality
 #
 def trigger_job(revision, buildername, times=1, files=None, dry_run=False,
-                extra_properties=None):
+                extra_properties=None, existing_only=False):
     """Trigger a job through self-serve.
 
     We return a list of all requests made.
@@ -351,6 +351,11 @@ def trigger_job(revision, buildername, times=1, files=None, dry_run=False,
             revision,
             buildername,
         )
+
+        if existing_only and (builder_to_trigger != buildername):
+            LOG.info("We won't trigger %s because we would have to trigger %s."
+                     % (buildername, builder_to_trigger))
+            return
 
         if builder_to_trigger != buildername and times != 1:
             # The user wants to trigger a downstream job,

--- a/mozci/mozci.py
+++ b/mozci/mozci.py
@@ -52,12 +52,7 @@ def _unique_build_request(buildername, revision):
                      "revision %s during this session. We don't allow "
                      "multiple requests." % (buildername, revision))
             return False
-        else:
-            if revision not in sch_mgr:
-                sch_mgr[revision] = []
-
-            sch_mgr[revision].append(buildername)
-            return True
+        return True
 
 
 def _status_summary(jobs):
@@ -353,8 +348,9 @@ def trigger_job(revision, buildername, times=1, files=None, dry_run=False,
         )
 
         if existing_only and (builder_to_trigger != buildername):
-            LOG.info("We won't trigger %s because we would have to trigger %s."
-                     % (buildername, builder_to_trigger))
+            LOG.info("We won't trigger %s because there is no working build."
+                     % buildername)
+            LOG.info("")
             return
 
         if builder_to_trigger != buildername and times != 1:
@@ -458,6 +454,14 @@ def trigger(builder, revision, files=[], dry_run=False, extra_properties=None):
 
     Returns a request.
     """
+    global SCHEDULING_MANAGER
+    sch_mgr = SCHEDULING_MANAGER
+
+    if revision not in sch_mgr:
+        sch_mgr[revision] = []
+
+    sch_mgr[revision].append(builder)
+
     repo_name = query_repo_name_from_buildername(builder)
     return buildapi.trigger_arbitrary_job(repo_name, builder, revision, files, dry_run,
                                           extra_properties)

--- a/mozci/scripts/alltalos.py
+++ b/mozci/scripts/alltalos.py
@@ -49,10 +49,11 @@ def parse_args(argv=None):
                         dest="pgo",
                         help="trigger pgo tests (not non-pgo).")
 
-    parser.add_argument("--existing-only",
+    parser.add_argument("--trigger-build-if-missing",
                         action="store_true",
-                        dest="existing_only",
-                        help="only retrigger jobs for which there is an existing build")
+                        dest="trigger_build_if_missing",
+                        help="trigger the build job even when there is no available. "
+                        "This will only alter the behaviour on try")
 
     parser.add_argument("--includes",
                         action="store",
@@ -84,10 +85,11 @@ def main():
     if options.repo_name in PGO_ONLY_BRANCHES or options.pgo:
         pgo = True
 
-    # On try we only run with existing_only=True
-    existing = False
-    if options.existing_only or options.repo_name == 'try':
-        existing = True
+    # on try we will change trigger_build_if_missing to False unless
+    # the developer ran with --trigger-build-if-missing
+    trigger_build_if_missing = True
+    if not options.trigger_build_if_missing and options.repo_name == 'try':
+        trigger_build_if_missing = False
 
     buildernames = build_talos_buildernames_for_repo(options.repo_name, pgo)
 
@@ -106,7 +108,7 @@ def main():
                     buildername=buildername,
                     times=options.times,
                     dry_run=options.dry_run,
-                    existing_only=existing)
+                    trigger_build_if_missing=trigger_build_if_missing)
 
 if __name__ == '__main__':
     main()

--- a/mozci/scripts/alltalos.py
+++ b/mozci/scripts/alltalos.py
@@ -84,8 +84,14 @@ def main():
     if options.repo_name in PGO_ONLY_BRANCHES or options.pgo:
         pgo = True
 
+    # On try we only run with existing_only=True
+    existing = False
+    if options.existing_only or options.repo_name == 'try':
+        existing = True
+
     buildernames = build_talos_buildernames_for_repo(options.repo_name, pgo)
 
+    # Filtering functionality
     filters_in, filters_out = [], []
 
     if options.includes:
@@ -100,7 +106,7 @@ def main():
                     buildername=buildername,
                     times=options.times,
                     dry_run=options.dry_run,
-                    existing_only=options.existing_only)
+                    existing_only=existing)
 
 if __name__ == '__main__':
     main()

--- a/mozci/scripts/alltalos.py
+++ b/mozci/scripts/alltalos.py
@@ -49,6 +49,11 @@ def parse_args(argv=None):
                         dest="pgo",
                         help="trigger pgo tests (not non-pgo).")
 
+    parser.add_argument("--existing-only",
+                        action="store_true",
+                        dest="existing_only",
+                        help="only retrigger jobs for which there is an existing build")
+
     parser.add_argument("--includes",
                         action="store",
                         dest="includes",
@@ -94,7 +99,8 @@ def main():
         trigger_job(revision=options.revision,
                     buildername=buildername,
                     times=options.times,
-                    dry_run=options.dry_run)
+                    dry_run=options.dry_run,
+                    existing_only=options.existing_only)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Example output of running "python mozci/scripts/alltalos.py --repo-name try --dry-run --existing-only --rev  b71c4e5e9542 --times 2" in a revision with android jobs only: https://pastebin.mozilla.org/8835070

We will need to clean up the logs a bit, but I believe this can be left for a later patch.

I had to move the SCHEDULING_MANAGER update to trigger() because _unique_build_request assumed checking for uniqueness implied triggering a build, which is not the case here. 
