### PR TITLE
Log the request_id in make_retrigger_request

### DIFF
--- a/mozci/sources/buildapi.py
+++ b/mozci/sources/buildapi.py
@@ -91,7 +91,8 @@ def make_retrigger_request(repo_name, request_id, count=1, priority=0, dry_run=T
         LOG.info('We would make a POST request to %s with the payload: %s' % (url, str(payload)))
         return None
 
-    LOG.info("We're going to re-trigger an existing completed job %i times." % count)
+    LOG.info("We're going to re-trigger an existing completed job with request_id: %s %i time(s)."
+             % (request_id, count))
     req = requests.post(
         url,
         headers={'Accept': 'application/json'},


### PR DESCRIPTION
The current format is good for mozci but not very useful for pulse_actions [1]. I believe just adding the request_id will not annoy mozci users and will be helpful to pulse_actions.

[1]
     Jun 11 10:23:43 pulse-actions app/worker.1: INFO:   Listening on exchange/treeherder/v1/job-actions, with topic buildbot.ash.# 
    Jun 11 10:23:44 pulse-actions app/worker.1: INFO:    We're going to re-trigger an existing completed job 1 times. 
