### PR TITLE
Only retrigger coalesced jobs if no other job exists

### DIFF
--- a/mozci/sources/buildjson.py
+++ b/mozci/sources/buildjson.py
@@ -5,7 +5,6 @@ systems: http://builddata.pub.build.mozilla.org/builddata/buildjson
 """
 import logging
 import os
-import time
 
 from mozci.utils.tzone import utc_dt, utc_time, utc_day
 from mozci.utils.transfer import load_file, path_to_file
@@ -152,14 +151,12 @@ def query_job_data(complete_at, request_id):
     if job:
         return job
 
-    # If we have not found the job, it might be that our cache is
-    # old. We will clean the cache and try one more time after 60
-    # seconds. If it fails, we will raise an Exception
-    BUILDS_CACHE = {}
-    seconds = 60
-    LOG.info("The request %d is not yet on %s. We are going to wait %i seconds for a new %s."
-             % (request_id, filename, seconds, filename))
-    time.sleep(seconds)
+    # If we have not found the job, it might be that our cache for this
+    # file is old. We will clean the cache and try one more time. If
+    # it fails, we will raise an Exception
+    LOG.debug("We did not find %d in %s, we'll clear our cache and try again."
+              % (request_id, filename))
+    del BUILDS_CACHE[filename]
 
     job = _find_job(request_id, _fetch_data(filename), filename)
     if job:


### PR DESCRIPTION
After talking with @jmaher, I believe this is the right behaviour.

Now we can call the script several times and it will only retrigger jobs that is has not retriggered before: https://pastebin.mozilla.org/8837180

(I ran the script 3 times against this revision: https://treeherder.mozilla.org/#/jobs?repo=mozilla-inbound&revision=1b5e08c07572&filter-resultStatus=success&filter-resultStatus=testfailed&filter-resultStatus=busted&filter-resultStatus=exception&filter-resultStatus=retry&filter-resultStatus=usercancel&filter-resultStatus=running&filter-resultStatus=pending&filter-resultStatus=coalesced )
