### PR TITLE
Issue 213: Try again when we get an IOError

### DIFF
--- a/mozci/utils/transfer.py
+++ b/mozci/utils/transfer.py
@@ -169,4 +169,11 @@ def load_file(filename, url):
     else:
         raise Exception("We received %s which is unexpected." % req.status_code)
 
-    return _load_json_file(filepath)
+    try:
+        return _load_json_file(filepath)
+
+    # Issue 213: sometimes we download a corrupted builds-*.js file
+    except IOError:
+        LOG.info("%s is corrupted, we will have to download a new one.", filename)
+        os.remove(filepath)
+        return load_file(filename, url)


### PR DESCRIPTION
Now, instead of getting IOError, we get:

mozilla_ci_tools[issue213]$ python mozci/scripts/trigger.py --coalesced  --repo-name mozilla-inbound --dry-run -r b6ac18409d64
06/24/2015 02:41:03 INFO:    /home/alice/.mozilla/mozci/builds-2015-06-21.js is corrupted, we will have to download a new one.
builds-2015-06-21.js: [>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>] Elapsed Time: 0:00:06 786.30 kB/s 4.0MB
06/24/2015 02:41:18 INFO:    We did not find any coalesced job
mozilla_ci_tools[issue213]$ 
