### PR TITLE
Issue 260: Always generate a file with debug output.

### DIFF
--- a/mozci/scripts/alltalos.py
+++ b/mozci/scripts/alltalos.py
@@ -5,10 +5,7 @@ import logging
 
 from mozci.mozci import trigger_job
 from mozci.platforms import build_talos_buildernames_for_repo, filter_buildernames
-
-logging.basicConfig(format='%(asctime)s %(levelname)s:\t %(message)s',
-                    datefmt='%m/%d/%Y %I:%M:%S')
-LOG = logging.getLogger()
+from mozci.utils.misc import setup_logging
 
 PGO_ONLY_BRANCHES = ['mozilla-aurora', 'mozilla-beta']
 
@@ -72,13 +69,10 @@ def main():
     options = parse_args()
 
     if options.debug:
-        LOG.setLevel(logging.DEBUG)
-        logging.getLogger("requests").setLevel(logging.DEBUG)
+        LOG = setup_logging(logging.DEBUG)
         LOG.info("Setting DEBUG level")
     else:
-        LOG.setLevel(logging.INFO)
-        # requests is too noisy and adds no value
-        logging.getLogger("requests").setLevel(logging.WARNING)
+        LOG = setup_logging(logging.INFO)
 
     pgo = False
     if options.repo_name in PGO_ONLY_BRANCHES or options.pgo:

--- a/mozci/scripts/trigger.py
+++ b/mozci/scripts/trigger.py
@@ -8,11 +8,7 @@ from mozci.mozci import backfill_revlist, trigger_range, \
 from mozci.sources.buildapi import find_all_by_status, make_retrigger_request, COALESCED
 from mozci.sources.pushlog import query_revisions_range_from_revision_and_delta
 from mozci.sources.pushlog import query_revisions_range, query_revision_info, query_pushid_range
-
-
-logging.basicConfig(format='%(asctime)s %(levelname)s:\t %(message)s',
-                    datefmt='%m/%d/%Y %I:%M:%S')
-LOG = logging.getLogger()
+from mozci.utils.misc import setup_logging
 
 
 def parse_args(argv=None):
@@ -193,13 +189,10 @@ def main():
     validate_options(options)
 
     if options.debug:
-        LOG.setLevel(logging.DEBUG)
-        logging.getLogger("requests").setLevel(logging.DEBUG)
+        LOG = setup_logging(logging.DEBUG)
         LOG.info("Setting DEBUG level")
     else:
-        LOG.setLevel(logging.INFO)
-        # requests is too noisy and adds no value
-        logging.getLogger("requests").setLevel(logging.WARNING)
+        LOG = setup_logging(logging.INFO)
 
     if options.coalesced:
         request_ids = find_all_by_status(options.repo_name, options.rev, COALESCED)

--- a/mozci/scripts/triggerbyfilters.py
+++ b/mozci/scripts/triggerbyfilters.py
@@ -11,10 +11,7 @@ from argparse import ArgumentParser
 
 from mozci.mozci import trigger_range, query_repo_name_from_buildername, query_builders
 from mozci.platforms import filter_buildernames
-
-logging.basicConfig(format='%(asctime)s %(levelname)s:\t %(message)s',
-                    datefmt='%m/%d/%Y %I:%M:%S')
-LOG = logging.getLogger()
+from mozci.utils.misc import setup_logging
 
 
 def parse_args(argv=None):
@@ -64,13 +61,10 @@ def main():
     options = parse_args()
 
     if options.debug:
-        LOG.setLevel(logging.DEBUG)
-        logging.getLogger("requests").setLevel(logging.DEBUG)
+        LOG = setup_logging(logging.DEBUG)
         LOG.info("Setting DEBUG level")
     else:
-        LOG.setLevel(logging.INFO)
-        # requests is too noisy and adds no value
-        logging.getLogger("requests").setLevel(logging.WARNING)
+        LOG = setup_logging(logging.INFO)
 
     filters_in = options.includes.split(',') + [options.repo]
     filters_out = []

--- a/mozci/utils/misc.py
+++ b/mozci/utils/misc.py
@@ -6,6 +6,7 @@ import logging
 import requests
 
 from mozci.utils.authentication import get_credentials
+from mozci.utils.transfer import path_to_file
 
 LOG = logging.getLogger('mozci')
 
@@ -41,3 +42,34 @@ def _all_urls_reachable(urls):
             return False
 
     return True
+
+
+def setup_logging(level):
+    """
+    Save every message (including debug ones) to ~/.mozilla/mozci/mozci-debug.log.
+
+    Log messages of level equal or greater then 'level' to the terminal.
+
+    As seen in:
+    https://docs.python.org/2/howto/logging-cookbook.html#logging-to-multiple-destinations
+    """
+    LOG = logging.getLogger('mozci')
+    logging.basicConfig(level=logging.DEBUG,
+                        format='%(asctime)s %(levelname)s:\t %(message)s',
+                        datefmt='%m/%d/%Y %I:%M:%S',
+                        filename=path_to_file('mozci-debug.log'),
+                        filemode='w')
+
+    console = logging.StreamHandler()
+    console.setLevel(level)
+    # console does not use the same formatter specified in basicConfig
+    # we have to set it again
+    formatter = logging.Formatter('%(asctime)s %(levelname)s:\t %(message)s',
+                                  datefmt='%m/%d/%Y %I:%M:%S')
+    console.setFormatter(formatter)
+    LOG.addHandler(console)
+
+    if level != logging.DEBUG:
+        # requests is too noisy and adds no value
+        logging.getLogger("requests").setLevel(logging.WARNING)
+    return LOG


### PR DESCRIPTION
This saves every log message to ~/.mozilla/mozci/mozci-debug.log. If a mozci-debug.log file already exists, it will be overwritten.

If the user wants to see the debug output on the terminal, the flag --debug still works.

https://pastebin.mozilla.org/8837737 is my mozci-debug.log file after running "python mozci/scripts/trigger.py -b "Android 4.0 armv7 API 11+ try opt test robocop-2" -r 6a49c86d0436 --dry-run
