### PR TITLE
Added --fill-in mode

### DIFF
--- a/mozci/platforms.py
+++ b/mozci/platforms.py
@@ -318,3 +318,15 @@ def filter_buildernames(include, exclude, buildernames):
         buildernames = filter(lambda x: word.lower() not in x.lower(), buildernames)
 
     return sorted(buildernames)
+
+
+def get_upstream_buildernames(repo_name):
+    """Return every upstream buildername in a repo."""
+    buildernames = filter_buildernames([repo_name],
+                                       ['hg bundle'],
+                                       fetch_allthethings_data()['builders'])
+    upstream_jobs = []
+    for buildername in buildernames:
+        if not is_downstream(buildername):
+            upstream_jobs.append(buildername)
+    return upstream_jobs


### PR DESCRIPTION
I asked Ryan what upstream jobs from https://pastebin.mozilla.org/8838040 the sheriffs would like --fill-in mode to trigger. He told me the only one they didn't want was 'mozilla-inbound hg bundle' (and maybe the spider-monkey ones, but he was not sure).

This will trigger every upstream job that is missing from a revision. On non-try repos this will automatically trigger the missing downstream jobs.
Mozilla-inbound output: https://pastebin.mozilla.org/8838045
