### PR TITLE
Also consider UNKNOWN jobs as running jobs

### DIFF
--- a/mozci/mozci.py
+++ b/mozci/mozci.py
@@ -75,6 +75,8 @@ def _status_summary(jobs):
             successful += 1
         if status == COALESCED:
             coalesced += 1
+        if status == UNKNOWN:
+            running += 1
 
     return (successful, pending, running, coalesced)
 


### PR DESCRIPTION
I forgot to push this a long time ago. Since UNKNOWN means that a job finished running but still isn't successful (and we cannot call query_job_data with it), it should count as running instead of being ignored.
