### PR TITLE
Moved functionality into find_backfill_revlist.

### DIFF
--- a/mozci/mozci.py
+++ b/mozci/mozci.py
@@ -459,9 +459,9 @@ def trigger(builder, revision, files=[], dry_run=False, extra_properties=None):
                                           extra_properties)
 
 
-def backfill_revlist(buildername, revisions):
+def _filter_backfill_revlist(buildername, revisions):
     """
-    Find the last known good job for that buildername iterating through the list of revisions.
+    Helper function to find the last known good job for a given buildername on a list of revisions.
 
     If a good job is found, we will only trigger_range() up to that revision instead of the
     complete list (subset of *revlist*).
@@ -487,3 +487,13 @@ def backfill_revlist(buildername, revisions):
 
     LOG.info("We only need to backfill %s" % new_revisions_list)
     return new_revisions_list
+
+
+def find_backfill_revlist(repo_url, revision, max_revisions, buildername):
+    """Determine which revisions we need to trigger in order to backfill."""
+    revlist = pushlog.query_revisions_range_from_revision_before_and_after(
+        repo_url=repo_url,
+        revision=revision,
+        before=max_revisions - 1,
+        after=0)
+    return _filter_backfill_revlist(buildername, revlist)

--- a/mozci/sources/pushlog.py
+++ b/mozci/sources/pushlog.py
@@ -88,16 +88,13 @@ def query_pushid_range(repo_url, start_id, end_id, version=2):
     return revisions
 
 
-def query_revisions_range_from_revision_and_delta(repo_url, revision, delta):
-    """
-    Function to get the start revision and end revision
-    based on given delta for the given push_revision.
-    """
+def query_revisions_range_from_revision_before_and_after(repo_url, revision, before, after):
+    """Get the start and end revisions based on the number of revisions before and after."""
     try:
         push_info = query_revision_info(repo_url, revision)
         pushid = int(push_info["pushid"])
-        start_id = pushid - delta
-        end_id = pushid + delta
+        start_id = pushid - before
+        end_id = pushid + after
         revlist = query_pushid_range(repo_url, start_id, end_id)
     except:
         raise Exception('Unable to retrieve pushlog data. '


### PR DESCRIPTION
I needed this for https://github.com/adusca/pulse_actions/pull/1 and it makes more sense as a mozci function.

In the process of moving this to mozci I noticed that back_revisions, delta and the first part of backfill were all essentially using the same function, so I did some refactoring.
