### PR TITLE
Fix TypeError on get_job_status

### DIFF
--- a/mozci/mozci.py
+++ b/mozci/mozci.py
@@ -119,7 +119,7 @@ def _determine_trigger_objective(revision, buildername, trigger_build_if_missing
     LOG.debug("List of matching jobs:")
     for job in build_jobs:
         try:
-            status = query_api.get_job_status()
+            status = query_api.get_job_status(job)
         except buildjson.BuildjsonException:
             LOG.debug("We have hit bug 1159279 and have to work around it. We will pretend that "
                       "we could not reach the files for it.")


### PR DESCRIPTION
I was getting this Error:

07/01/2015 08:01:25 INFO:  
07/01/2015 08:01:25 ERROR:   get_job_status() takes exactly 2 arguments (1 given)
Traceback (most recent call last):
  File "mozci/scripts/trigger.py", line 241, in main
    files=options.files
  File "/home/alice/mozilla_ci_tools/mozci/mozci.py", line 432, in trigger_range
    files=files)
  File "/home/alice/mozilla_ci_tools/mozci/mozci.py", line 343, in trigger_job
    trigger_build_if_missing
  File "/home/alice/mozilla_ci_tools/mozci/mozci.py", line 122, in _determine_trigger_objective
    status = query_api.get_job_status()
TypeError: get_job_status() takes exactly 2 arguments (1 given)

I believe this fixes it.

r? @vaibhavmagarwal 
