### PR TITLE
Add 'pgo' to the existing list of jobs to be removed while fill_in

### DIFF
--- a/mozci/mozci.py
+++ b/mozci/mozci.py
@@ -448,7 +448,7 @@ def fill_in_revision(repo_name, revision, dry_run=False):
     Trigger all missing jobs for a given revision
     """
     all_buildernames = filter_buildernames([repo_name],
-                                           ['hg bundle', 'b2g'],
+                                           ['hg bundle', 'b2g', 'pgo'],
                                            allthethings.list_builders())
 
     for buildername in all_buildernames:


### PR DESCRIPTION
Joel has commented ( https://bugzilla.mozilla.org/show_bug.cgi?id=1178524#c10 ) that we should not fill-in pgo jobs by default and we will possibly have a different button for it.
