### PR TITLE
Fix fill_in_revision function name to tigger_missing_jobs_for_revision.

### DIFF
--- a/mozci/mozci.py
+++ b/mozci/mozci.py
@@ -443,9 +443,10 @@ def trigger(builder, revision, files=[], dry_run=False, extra_properties=None):
                                           extra_properties)
 
 
-def fill_in_revision(repo_name, revision, dry_run=False):
+def trigger_missing_jobs_for_revision(repo_name, revision, dry_run=False):
     """
-    Trigger all missing jobs for a given revision
+    Trigger missing jobs for a given revision.
+    Jobs have any of ('hg bundle', 'b2g', 'pgo') in their buildername will not be triggered.
     """
     all_buildernames = filter_buildernames([repo_name],
                                            ['hg bundle', 'b2g', 'pgo'],

--- a/mozci/scripts/misc/find_logs_for_jobs.py
+++ b/mozci/scripts/misc/find_logs_for_jobs.py
@@ -42,4 +42,4 @@ if __name__ == "__main__":
 
     jobs = query_jobs_buildername(options.buildername, options.rev)
     for schedule_info in jobs:
-        print schedule_info["properties"]["log_url"]
+        print schedule_info["properties"]["packageUrl"]

--- a/mozci/scripts/misc/results_per_suite.py
+++ b/mozci/scripts/misc/results_per_suite.py
@@ -12,8 +12,8 @@ def get_query(repo_name):
     query = {"from": "unittest",
              "groupby": ["build.name", "run.buildbot_status"],
              "limit": 10000,
-             "where": {"and":[
-                 {"eq": {"etl.id":0}},
+             "where": {"and": [
+                 {"eq": {"etl.id": 0}},
                  {"eq": {"build.branch": repo_name}}
              ]}}
     return json.dumps(query)
@@ -67,15 +67,17 @@ def main():
         for buildername in sorted(builders.keys(),
                                   key=lambda b: builders[b]['success rate']):
             values = builders[buildername]
-            writer.writerow([buildername,
-                             values['success'],
-                             values['warnings'],
-                             values['failure'],
-                             values['retry'],
-                             values['exception'],
-                             values['cancelled'],
-                             "%.2f%%" % values['success rate']
-                         ])
+            writer.writerow(
+                [
+                    buildername,
+                    values['success'],
+                    values['warnings'],
+                    values['failure'],
+                    values['retry'],
+                    values['exception'],
+                    values['cancelled'],
+                    "%.2f%%" % values['success rate']
+                ])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
We changed the action from "fill_in" to "trigger_missing_jobs" [1]
So it is better to that here too for consistency.

[1] - https://github.com/mozilla/treeherder/pull/747/files#diff-1dcf92fc8473c8a5e650f4b7a8220c65R197
