### PR TITLE
Issue 296: Look for 'request_id' key when 'requests' doesn't exist

### DIFF
--- a/mozci/query_jobs.py
+++ b/mozci/query_jobs.py
@@ -54,7 +54,11 @@ class BuildApi(QueryApi):
 
     def get_buildapi_request_id(self, repo_name, job):
         """ Method to return buildapi's request_id for a job. """
-        return job["requests"][0]["request_id"]
+        # Most jobs have a "requests" key, but sometimes there is just
+        # a "request_id" key.
+        if "requests" in job:
+            return job["requests"][0]["request_id"]
+        return job["request_id"]
 
     def get_matching_jobs(self, repo_name, revision, buildername):
         """Return all jobs that matched the criteria."""


### PR DESCRIPTION
All the jobs I tested had at least one of those keys.

r? @vaibhavmagarwal 

With this patch " python mozci/scripts/triggerbyfilters.py try d81a7a9390a6 -i mochitest-devtools-chrome --times 6 --dry-run" doesn't break.
