### PR TITLE
Add memory-saving mode to buildjson.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ setup(
     install_requires=[
         'beautifulsoup4>=4.3.2',
         'bugsy>=0.4.0',
+        'ijson>=2.2',
         'progressbar>=2.3',
         'requests>=2.5.1',
         'keyring>=5.3',


### PR DESCRIPTION
This allows pulse_actions to use ijson instead of the normal json module without changing anything about the behaviour of the script.

If the experiment works it might be worth it to make this optimization available for normal mozci usage, but for now I just want to see if this solves our memory problems.

r? @armenzg 
