### PR TITLE
Issue 301 - Switch to new TravisCI infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,5 @@
+sudo: false
+
 language: python
 
 python:


### PR DESCRIPTION
By switching to the new insfrastructure we get:
- more isolation (thanks to containers)
- faster builds
- CPU resources are guaranteed
- caching available

caveat: As you can’t use sudo on the new container-based infrastructure,
you need to use the addons.apt.packages and addons.apt.sources plugins
to install packages and package sources

[1]
http://docs.travis-ci.com/user/migrating-from-legacy/?utm_source=legacy-notice&utm_medium=banner&utm_campaign=legacy-upgrade
