### PR TITLE
Also count failed jobs as potential jobs

### DIFF
--- a/mozci/mozci.py
+++ b/mozci/mozci.py
@@ -17,7 +17,7 @@ import logging
 from mozci.platforms import determine_upstream_builder, is_downstream, filter_buildernames
 from mozci.sources import allthethings, buildapi, buildjson, pushlog
 from mozci.query_jobs import PENDING, RUNNING, SUCCESS, UNKNOWN,\
-    COALESCED, BuildApi, TreeherderApi
+    COALESCED, WARNING, FAILURE, EXCEPTION, RETRY, BuildApi, TreeherderApi
 from mozci.utils.misc import _all_urls_reachable
 from mozci.utils.transfer import path_to_file, clean_directory
 
@@ -64,21 +64,22 @@ def _status_summary(jobs):
     pending = 0
     running = 0
     coalesced = 0
+    failed = 0
 
     for job in jobs:
         status = QUERY_SOURCE.get_job_status(job)
         if status == PENDING:
             pending += 1
-        if status == RUNNING:
+        if status in (RUNNING, UNKNOWN):
             running += 1
         if status == SUCCESS:
             successful += 1
         if status == COALESCED:
             coalesced += 1
-        if status == UNKNOWN:
-            running += 1
+        if status in (FAILURE, WARNING, EXCEPTION, RETRY):
+            failed += 1
 
-    return (successful, pending, running, coalesced)
+    return (successful, pending, running, coalesced, failed)
 
 
 def _determine_trigger_objective(revision, buildername, trigger_build_if_missing=True):
@@ -384,11 +385,12 @@ def trigger_range(buildername, revisions, times=1, dry_run=False,
 
         # 1) How many potentially completed jobs can we get for this buildername?
         matching_jobs = QUERY_SOURCE.get_matching_jobs(repo_name, rev, buildername)
-        successful_jobs, pending_jobs, running_jobs = _status_summary(matching_jobs)[0:3]
+        successful_jobs, pending_jobs, running_jobs, _, failed_jobs = _status_summary(matching_jobs)
 
-        potential_jobs = pending_jobs + running_jobs + successful_jobs
-        LOG.debug("We found %d pending jobs, %d running jobs and %d successful_jobs." %
-                  (pending_jobs, running_jobs, successful_jobs))
+        potential_jobs = pending_jobs + running_jobs + successful_jobs + failed_jobs
+        # TODO: change this debug message when we have a less hardcoded _status_summary
+        LOG.debug("We found %d pending/running jobs, %d successful jobs and "
+                  "%d failed jobs" % (pending_jobs + running_jobs, successful_jobs, failed_jobs))
 
         if potential_jobs >= times:
             LOG.info("We have %d job(s) for '%s' which is enough for the %d job(s) we want." %

--- a/test/test_mozci.py
+++ b/test/test_mozci.py
@@ -104,22 +104,22 @@ class TestJobValidation(unittest.TestCase):
         We will only test _status_summary with simple mocks of get_job_status here.
         This test is with a success state.
         """
-        assert mozci.mozci._status_summary(self.jobs) == (1, 0, 0, 0)
+        assert mozci.mozci._status_summary(self.jobs) == (1, 0, 0, 0, 0)
 
     @patch('mozci.query_jobs.BuildApi.get_job_status',
            return_value=PENDING)
     def test_status_summary_pending(self, get_status):
         """Test _status_summary with a running state."""
-        assert mozci.mozci._status_summary(self.jobs) == (0, 1, 0, 0)
+        assert mozci.mozci._status_summary(self.jobs) == (0, 1, 0, 0, 0)
 
     @patch('mozci.query_jobs.BuildApi.get_job_status',
            return_value=RUNNING)
     def test_status_summary_running(self, get_status):
         """Test _status_summary with a running state."""
-        assert mozci.mozci._status_summary(self.jobs) == (0, 0, 1, 0)
+        assert mozci.mozci._status_summary(self.jobs) == (0, 0, 1, 0, 0)
 
     @patch('mozci.query_jobs.BuildApi.get_job_status',
            return_value=COALESCED)
     def test_status_summary_coalesced(self, get_status):
         """Test _status_summary with a coalesced state."""
-        assert mozci.mozci._status_summary(self.jobs) == (0, 0, 0, 1)
+        assert mozci.mozci._status_summary(self.jobs) == (0, 0, 0, 1, 0)


### PR DESCRIPTION
Today, during the automatic backfilling experiment, we noticed that sometimes mozci would trigger a job after calling trigger_range with times=1 when 5 runs of the job already existed.

After investigating, I discovered that this is because mozci didn't consider failed jobs as potential jobs. I know that for pulse_actions we definitely don't want to trigger a job extra times because all of the previous runs were failures, but I'm not sure we should add an argument to keep the previous behaviour or if counting failed jobs as potential jobs is something we always want to do in mozci.

r? @armenzg 
