### PR TITLE
Add times to extra_properties in trigger_all_talos_jobs function

### DIFF
--- a/mozci/mozci.py
+++ b/mozci/mozci.py
@@ -484,7 +484,8 @@ def trigger_all_talos_jobs(repo_name, revision, times, dry_run=False):
                       times=times,
                       dry_run=dry_run,
                       extra_properties={'mozci_request': {
-                                        'type': 'trigger_all_talos_jobs'}
+                                        'type': 'trigger_all_talos_jobs',
+                                        'times': times}
                                         })
 
 


### PR DESCRIPTION
We will also need times in extra_properties in trigger_all_talos_jobs function, when we call it from pulse_actions on builds finish event.
r?
