### PR TITLE
Fix repository name not found exception for new buildernames.

### DIFF
--- a/mozci/mozci.py
+++ b/mozci/mozci.py
@@ -245,7 +245,8 @@ def query_repo_name_from_buildername(buildername, clobber=False):
     repositories = buildapi.query_repositories(clobber)
     ret_val = None
     for repo_name in repositories:
-        if (' %s ' % repo_name) in buildername or ('_%s_' % repo_name) in buildername:
+        if any(True for iterable in [' %s ', '_%s_', '-%s-']
+               if iterable % repo_name in buildername):
             ret_val = repo_name
             break
 


### PR DESCRIPTION
Looks like there were some new buildernames added to allthethings.json
I see this error in pulse_actions:

``` python
Traceback (most recent call last): 
Aug 09 08:58:04 pulse-actions app/worker2.1:   File "pulse_actions/worker.py", line 61, in run_pulse 
Aug 09 08:58:04 pulse-actions app/worker2.1:     pulse.listen() 
Aug 09 08:58:04 pulse-actions app/worker2.1:   File "/app/.heroku/python/lib/python2.7/site-packages/mozillapulse/consumers.py", line 181, in listen 
Aug 09 08:58:04 pulse-actions app/worker2.1:     self.connection.drain_events() 
Aug 09 08:58:04 pulse-actions app/worker2.1:   File "/app/.heroku/python/lib/python2.7/site-packages/kombu/connection.py", line 275, in drain_events 
Aug 09 08:58:04 pulse-actions app/worker2.1:     return self.transport.drain_events(self.connection, **kwargs) 
Aug 09 08:58:04 pulse-actions app/worker2.1:   File "/app/.heroku/python/lib/python2.7/site-packages/kombu/transport/pyamqp.py", line 95, in drain_events 
Aug 09 08:58:04 pulse-actions app/worker2.1:     return connection.drain_events(**kwargs) 
Aug 09 08:58:04 pulse-actions app/worker2.1:   File "/app/.heroku/python/lib/python2.7/site-packages/amqp/connection.py", line 325, in drain_events 
Aug 09 08:58:04 pulse-actions app/worker2.1:     return amqp_method(channel, args, content) 
Aug 09 08:58:04 pulse-actions app/worker2.1:   File "/app/.heroku/python/lib/python2.7/site-packages/amqp/channel.py", line 1908, in _basic_deliver 
Aug 09 08:58:04 pulse-actions app/worker2.1:     fun(msg) 
Aug 09 08:58:04 pulse-actions app/worker2.1:   File "/app/.heroku/python/lib/python2.7/site-packages/kombu/messaging.py", line 596, in _receive_callback 
Aug 09 08:58:04 pulse-actions app/worker2.1:     return on_m(message) if on_m else self.receive(decoded, message) 
Aug 09 08:58:04 pulse-actions app/worker2.1:   File "/app/.heroku/python/lib/python2.7/site-packages/kombu/messaging.py", line 563, in receive 
Aug 09 08:58:04 pulse-actions app/worker2.1:     [callback(body, message) for callback in callbacks] 
Aug 09 08:58:04 pulse-actions app/worker2.1:   File "pulse_actions/worker.py", line 52, in handler_with_dry_run 
Aug 09 08:58:04 pulse-actions app/worker2.1:     return event_handler(data, message, dry_run) 
Aug 09 08:58:04 pulse-actions app/worker2.1:   File "/app/pulse_actions/handlers/route_functions.py", line 12, in route 
Aug 09 08:58:04 pulse-actions app/worker2.1:     treeherder_resultset.on_resultset_action_event(data, message, dry_run) 
Aug 09 08:58:04 pulse-actions app/worker2.1:   File "/app/pulse_actions/handlers/treeherder_resultset.py", line 32, in on_resultset_action_event 
Aug 09 08:58:04 pulse-actions app/worker2.1:     trigger_missing_jobs_for_revision(repo_name, revision, dry_run=dry_run) 
Aug 09 08:58:04 pulse-actions app/worker2.1:   File "/app/.heroku/python/lib/python2.7/site-packages/mozci/mozci.py", line 471, in trigger_missing_jobs_for_revision 
Aug 09 08:58:04 pulse-actions app/worker2.1:     'type': 'trigger_missing_jobs_for_revision'} 
Aug 09 08:58:04 pulse-actions app/worker2.1:   File "/app/.heroku/python/lib/python2.7/site-packages/mozci/mozci.py", line 373, in trigger_range 
Aug 09 08:58:04 pulse-actions app/worker2.1:     repo_name = query_repo_name_from_buildername(buildername) 
Aug 09 08:58:04 pulse-actions app/worker2.1:   File "/app/.heroku/python/lib/python2.7/site-packages/mozci/mozci.py", line 255, in query_repo_name_from_buildername 
Aug 09 08:58:04 pulse-actions app/worker2.1:     query_repo_name_from_buildername(buildername, clobber=True) 
Aug 09 08:58:04 pulse-actions app/worker2.1:   File "/app/.heroku/python/lib/python2.7/site-packages/mozci/mozci.py", line 258, in query_repo_name_from_buildername 
Aug 09 08:58:04 pulse-actions app/worker2.1:     raise Exception("Repository name not found in buildername. " 
Aug 09 08:58:04 pulse-actions app/worker2.1: Exception: Repository name not found in buildername. Please provide a correct buildername. 
```

This patch fixes it. r?
