### PR TITLE
Don't trigger Windows 10 talos jobs by default.

### DIFF
--- a/mozci/platforms.py
+++ b/mozci/platforms.py
@@ -273,6 +273,10 @@ def build_talos_buildernames_for_repo(repo_name, pgo_only=False):
         talos_jobs = pgo_jobs.union(non_pgo_jobs)
 
     for builder in talos_jobs:
+        # This is a temporary hack to not trigger 'Windows 10' jobs on try.
+        # Remove it when not necessary.
+        if 'Windows 10' in builder:
+            continue
         retVal.append(builder)
 
     retVal.sort()


### PR DESCRIPTION
Bought from https://github.com/armenzg/mozilla_ci_tools/pull/324#issuecomment-130845152

@armenzg I totally forgot about sending a patch for that issue. This patch will not trigger 'win 10' talos jobs on try by 'trigger_all_talos_jobs' button. One can trigger windows 10 talos jobs via triggerbyfilters.py, so there is still a way to trigger them, just not by default. 
r?
