### PR TITLE
Fix weird 0 jobs message.

### DIFF
--- a/mozci/scripts/triggerbyfilters.py
+++ b/mozci/scripts/triggerbyfilters.py
@@ -89,6 +89,10 @@ def main():
 
     buildernames = filter_buildernames(filters_in, filters_out, query_builders())
 
+    if len(buildernames) == 0:
+        LOG.info("0 jobs match these filters, please try again.")
+        return
+
     cont = raw_input("%i jobs will be triggered, do you wish to continue? y/n/d (d=show details) "
                      % len(buildernames))
     if cont.lower() == 'd':


### PR DESCRIPTION
triggerbyfilters asked if users were sure they wanted to trigger 0 jobs. This makes the message less weird (although less amusing)).
## 

 <Gijs> 0 jobs will be triggered, do you wish to continue? y/n/d (d=show details)
10:33 — Gijs cries some more
