### PR TITLE
Bug 1209722 - Refactor to allow adding Buildbot jobs to a TC task

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,9 @@ develop-eggs
 .installed.cfg
 *.egg-info
 
+# ?
+.cache
+
 # venv
 venv
 

--- a/mozci/ci_manager.py
+++ b/mozci/ci_manager.py
@@ -80,6 +80,9 @@ class TaskclusterManager(BaseCIManager):
     def schedule_graph(self, task_graph, *args, **kwargs):
         return tc.schedule_graph(task_graph, *args, **kwargs)
 
+    def extend_task_graph(self, task_graph_id, task_graph, *args, **kwargs):
+        return tc.extend_task_graph(task_graph_id, task_graph, *args, **kwargs)
+
     def schedule_arbitrary_job(self, repo_name, revision, uuid, *args, **kwargs):
         pass
 
@@ -121,7 +124,7 @@ class TaskClusterBuildbotManager(TaskclusterManager):
         :rtype: dict
 
         """
-        task_graph = buildbot_bridge.generate_task_graph(
+        task_graph = buildbot_bridge.generate_builders_tc_graph(
             repo_name=repo_name,
             revision=revision,
             builders_graph=builders_graph,
@@ -130,10 +133,10 @@ class TaskClusterBuildbotManager(TaskclusterManager):
             task_graph=task_graph, *args, **kwargs)
 
     def schedule_arbitrary_job(self, repo_name, revision, uuid, *args, **kwargs):
-        task_graph = buildbot_bridge.generate_graph_from_builder(
+        task_graph = buildbot_bridge.generate_graph_from_builders(
             repo_name=repo_name,
             revision=revision,
-            buildername=uuid,
+            buildernames=[uuid],
             *args, **kwargs
         )
         return super(TaskClusterBuildbotManager, self).schedule_graph(

--- a/mozci/errors.py
+++ b/mozci/errors.py
@@ -2,11 +2,7 @@
 """This module holds custom-named exceptions"""
 
 
-class MozciError(Exception):
-    pass
-
-
-class TreeherderError(Exception):
+class AuthenticationError(Exception):
     pass
 
 
@@ -18,9 +14,17 @@ class BuildjsonError(Exception):
     pass
 
 
-class PushlogError(Exception):
+class MozciError(Exception):
     pass
 
 
-class AuthenticationError(Exception):
+class TaskClusterError(Exception):
+    pass
+
+
+class TreeherderError(Exception):
+    pass
+
+
+class PushlogError(Exception):
     pass

--- a/mozci/platforms.py
+++ b/mozci/platforms.py
@@ -11,7 +11,20 @@ LOG = logging.getLogger('mozci')
 
 
 def get_builder_information(buildername):
-    """Return all metadata from allthethings associated to a builder."""
+    """Return all metadata from allthethings associated to a builder.
+
+    Relevant data:
+    {
+        'properties': {
+            'branch':    'try',
+            'platform':  'linux64',
+            'product':   'firefox',
+            'repo_path': 'try'
+        },
+        'shortname': 'try_ubuntu64_vm_test-mochitest-1'
+    }
+
+    """
     return fetch_allthethings_data()['builders'][buildername]
 
 

--- a/mozci/sources/tc.py
+++ b/mozci/sources/tc.py
@@ -2,15 +2,150 @@
 This module allow us to interact with taskcluster through the taskcluster
 client.
 """
+from __future__ import absolute_import
+
 import datetime
 import json
 import logging
+import os
 import traceback
 
 import taskcluster as taskcluster_client
+from taskcluster.utils import slugId, fromNow
+
+from mozci.errors import TaskClusterError
+from mozci.sources.buildapi import query_repo_url
+from mozci.sources.pushlog import query_revision_info
+
 
 LOG = logging.getLogger('mozci')
-TASKCLUSTER_TOOLS_HOST = 'https://tools.taskcluster.net'
+METADATA = None
+TC_TOOLS_HOST = 'https://tools.taskcluster.net'
+TC_TASK_INSPECTOR = "%s/task-inspector/#" % TC_TOOLS_HOST
+TC_TASK_GRAPH_INSPECTOR = "%s/task-graph-inspector/#" % TC_TOOLS_HOST
+
+
+def credentials_available():
+    client_id = os.environ.get('TASKCLUSTER_CLIENT_ID', None)
+    token = os.environ.get('TASKCLUSTER_TOKEN', None)
+
+    if client_id and token:
+        return True
+    else:
+        LOG.error(
+            "Make sure that you create permanent credentials and you "
+            "set these environment variables: TASKCLUSTER_CLIENT_ID & "
+            "TASKCLUSTER_ACCESS_TOKEN"
+        )
+        return False
+
+
+def handle_auth_failure(e):
+    # Hack until we fix it in the issue
+    if str(e) == "Authorization Failed":
+        LOG.error("The taskclaster client that you specified is lacking "
+                  "the right set of scopes.")
+        LOG.error("Run this same command with --debug and you will see "
+                  "the missing scopes (the output comes from the "
+                  "taskcluster python client)")
+    elif str(e) == "Authentication Error":
+        LOG.error("Make sure that you create permanent credentials and you "
+                  "set these environment variables: TASKCLUSTER_CLIENT_ID & "
+                  "TASKCLUSTER_ACCESS_TOKEN")
+
+
+def _query_metadata(repo_name, revision, name, description=None):
+    global METADATA
+
+    if not METADATA:
+        repo_url = query_repo_url(repo_name)
+        push_info = query_revision_info(repo_url, revision)
+
+        if not description:
+            description = 'Task graph generated via Mozilla CI tools'
+
+        METADATA = {
+            'description': description,
+            'owner': push_info['user'],
+            'source': '%s/rev/%s' % (repo_url, revision),
+        }
+
+    result = {'name': name}
+    result.update(METADATA)
+
+    return result
+
+
+def create_task(repo_name, revision, **kwargs):
+    """ Create a TC task.
+
+    NOTE: This code needs to be tested for normal TC tasks to determine
+    if the default values would also work for non BBB tasks.
+    """
+    metadata = _query_metadata(
+        repo_name,
+        revision,
+        name=kwargs.get('metadata_name')
+    )
+
+    task_id = kwargs.get('taskId', slugId())
+
+    task_definition = {
+        'taskId': task_id,
+        # Do not retry the task if it fails to run successfuly
+        'reruns': kwargs.get('reruns', 0),
+        'task': {
+            'workerType': kwargs['workerType'],  # mandatory
+            'provisionerId': kwargs['provisionerId'],  # mandatory
+            'created': kwargs.get('created', fromNow('0d')),
+            'deadline': kwargs.get('deadline', fromNow('1d')),
+            'expires': kwargs.get('deadline', fromNow('1d')),
+            'payload': kwargs.get('payload', {}),
+            'metadata': kwargs.get('metadata', metadata),
+            'schedulerId': kwargs.get('schedulerId', 'task-graph-scheduler'),
+            'tags': kwargs.get('tags', {}),
+            'extra': kwargs.get('extra', {}),
+            'routes': kwargs.get('routes', []),
+            'priority': kwargs.get('priority', 'normal'),
+            'retries': kwargs.get('retries', 5),
+            'scopes': kwargs.get('scopes', []),
+        }
+    }
+
+    if kwargs.get('taskGroupId'):
+        task_definition['task']['taskGroupId'] = kwargs.get('taskGroupId', task_id),
+
+    return task_definition
+
+
+def _recreate_task(task_id):
+    one_year = 365
+    queue = taskcluster_client.Queue()
+    task = queue.task(task_id)
+
+    LOG.debug("Original task: (Limit 1024 char)")
+    LOG.debug(str(json.dumps(task))[:1024])
+
+    # Start updating the task
+    task['taskId'] = taskcluster_client.slugId()
+
+    artifacts = task['payload'].get('artifacts', {})
+    for artifact, definition in artifacts.iteritems():
+        definition['expires'] = taskcluster_client.fromNow('%s days' % one_year)
+
+    # https://bugzilla.mozilla.org/show_bug.cgi?id=1190660
+    # TC workers create public logs which are 365 days; if the task expiration
+    # date is the same or less than that we won't have logs for the task
+    task['expires'] = taskcluster_client.fromNow('%s days' % (one_year + 1))
+    now = datetime.datetime.utcnow()
+    tomorrow = now + datetime.timedelta(hours=24)
+    task['created'] = taskcluster_client.stringDate(now)
+    task['deadline'] = taskcluster_client.stringDate(tomorrow)
+
+    LOG.debug("Contents of new task: (Limit 1024 char)")
+    LOG.debug(str(task)[:1024])
+
+    return task
 
 
 def retrigger_task(task_id, dry_run=False):
@@ -30,81 +165,118 @@ def retrigger_task(task_id, dry_run=False):
 
     http://docs.taskcluster.net/queue/api-docs/#createTask
     """
-    one_year = 365
-    new_task_id = 0
+    if not credentials_available():
+        return None
 
+    results = None
+    # XXX: evaluate this code for when we can still extend the graph
+    #      insted of scheduling a new one
     try:
-        queue = taskcluster_client.Queue()
-        task = queue.task(task_id)
+        # Copy the task with fresh timestamps
+        new_task = _recreate_task(task_id)
 
-        LOG.debug("Original task: (Limit 1024 char)")
-        LOG.debug(str(json.dumps(task))[:1024])
-        new_task_id = taskcluster_client.slugId()
-
-        artifacts = task['payload'].get('artifacts', {})
-        for artifact, definition in artifacts.iteritems():
-            definition['expires'] = taskcluster_client.fromNow('%s days' % one_year)
-
-        # The task group will be identified by the ID of the only
-        # task in the group
-        task['taskGroupId'] = new_task_id
-        # https://bugzilla.mozilla.org/show_bug.cgi?id=1190660
-        # TC workers create public logs which are 365 days; if the task expiration
-        # date is the same or less than that we won't have logs for the task
-        task['expires'] = taskcluster_client.fromNow('%s days' % (one_year + 1))
-        now = datetime.datetime.utcnow()
-        tomorrow = now + datetime.timedelta(hours=24)
-        task['created'] = taskcluster_client.stringDate(now)
-        task['deadline'] = taskcluster_client.stringDate(tomorrow)
-
-        LOG.debug("Contents of new task: (Limit 1024 char)")
-        LOG.debug(str(task)[:1024])
+        # Create the graph
+        task_graph = generate_task_graph(
+            scopes=[],
+            tasks=[new_task],
+            metadata=new_task['metadata']
+        )
 
         if not dry_run:
+            LOG.info("Attempting to schedule new graph")
+            results = schedule_graph(task_graph)
+            '''
             LOG.info("Attempting to schedule new task with task_id: {}".format(new_task_id))
             result = queue.createTask(new_task_id, task)
             LOG.debug(json.dumps(result))
-            LOG.info("{}/task-inspector/#{}".format(TASKCLUSTER_TOOLS_HOST, new_task_id))
+            LOG.info("{}/task-inspector/#{}".format(TC_TOOLS_HOST, new_task_id))
+            '''
         else:
             LOG.info("Dry-run mode: Nothing was retriggered.")
 
     except taskcluster_client.exceptions.TaskclusterRestFailure as e:
         traceback.print_exc()
-        new_task_id = -1
 
     except taskcluster_client.exceptions.TaskclusterAuthFailure as e:
-        # Hack until we fix it in the issue
-        if str(e) == "Authorization Failed":
-            LOG.error("The taskclaster client that you specified is lacking "
-                      "the right set of scopes.")
-            LOG.error("Run this same command with --debug and you will see "
-                      "the missing scopes (the output comes from the "
-                      "taskcluster python client)")
-        elif str(e) == "Authentication Error":
-            LOG.error("Make sure that you create permanent credentials and you "
-                      "set these environment variables: TASKCLUSTER_CLIENT_ID & "
-                      "TASKCLUSTER_ACCESS_TOKEN")
-        new_task_id = -1
+        handle_auth_failure(e)
 
-    return new_task_id
+    return results
 
 
-def schedule_graph(task_graph, dry_run=False):
+def schedule_graph(task_graph, task_graph_id=None, dry_run=False):
     """ It schedules a TaskCluster graph and returns its id.
 
     :param task_graph: It is a TaskCluster graph as defined in here:
         http://docs.taskcluster.net/scheduler/api-docs/#createTaskGraph
     :type task_graph: json
+    :param task_graph_id: TC graph id to which this task belongs to
+    :type task_graph_id: str
     :param dry_run: It does not schedule the graph
     :type dry_run: bool
     :returns: task graph id.
     :rtype: int
 
     """
-    graph_id = taskcluster_client.slugId()
+    if not credentials_available():
+        return None
+
+    if not task_graph_id:
+        task_graph_id = taskcluster_client.slugId()
     scheduler = taskcluster_client.Scheduler()
+    # We print to stdout instead of using the standard logging with dates and info levels
+    # XXX: Use a different formatter for other tools to work better with this code
+    print(json.dumps(task_graph, indent=4))
     if dry_run:
         LOG.info("DRY-RUN: We have not scheduled the graph.")
     else:
-        scheduler.createTaskGraph(graph_id, task_graph)
-    return graph_id
+        try:
+            result = scheduler.createTaskGraph(task_graph_id, task_graph)
+            LOG.info("See the graph in %s%s" % (TC_TASK_GRAPH_INSPECTOR, task_graph_id))
+            return result
+        except taskcluster_client.exceptions.TaskclusterAuthFailure as e:
+            handle_auth_failure(e)
+
+
+def extend_task_graph(task_graph_id, task_graph, dry_run=False):
+    """
+
+    From: http://docs.taskcluster.net/scheduler/api-docs/#extendTaskGraph
+
+    Safety, it is only safe to call this API end-point while the task-graph
+    being modified is still running. If the task-graph is finished or blocked,
+    this method will leave the task-graph in this state. Hence, it is only
+    truly safe to call this API end-point from within a task in the task-graph
+    being modified.
+
+    returns Task-Graph Status Response
+    """
+    # XXX: handle the case when the task-graph is not running
+    scheduler = taskcluster_client.Scheduler()
+    if dry_run:
+        LOG.info("DRY-RUN: We have not extended the graph.")
+    else:
+        print task_graph_id
+        print(json.dumps(task_graph, indent=4))
+        return scheduler.extendTaskGraph(task_graph_id, task_graph)
+
+
+def generate_task_graph(scopes, tasks, repo_name=None, revision=None,
+                        metadata=None):
+    if 'scheduler:create-task-graph' not in scopes:
+        scopes.append('scheduler:create-task-graph')
+
+    if not metadata:
+        if repo_name and revision:
+            metadata = _query_metadata(repo_name, revision, 'task graph local')
+        else:
+            raise TaskClusterError(
+                "You have to either specify repo_name/revision or metadata"
+            )
+
+    # XXX: we could validation in here
+    task_graph = {
+        'scopes': scopes,
+        'tasks': tasks,
+        'metadata': metadata
+    }
+    return task_graph


### PR DESCRIPTION
This allows scheduling Buildbot builders for TaskCluster task.
This is useful for the TaskCluster migration process to validate
TC generated builds against the Buildbot test infrastructure.
## ci_manager.py
- add extend_task_graph() to TaskclusterManager
## buildbot_to_taskcluster.py
- allow appending builders to a TC task
- Drop support to specify only one builder with --builder (use
  --builders instead)
- Add --append-to-task-id
## buildbot_bridge.py
- broken down generate_task_graph() to _generate_tasks()
- added append_builders_to_task_id()
- Rename many functions to be more accurate
- Better doc strings
- Multi tier graph and validation
- buildbot_graph_builder() generates a buildbot graph from builders' list
- Switch Exception for MozciError
- Remove redundant _validate_builders_graph()
- Better docstring for generate_builders_tc_graph() and append_builders_to_task_id()
- _create_task() to call create_task() from tc module
- parent_task_id in the properties of a task is used by Mozharness
  to find the artifacts from a specific task without creating a
  dependency
## tc.py
- added extend_task_graph()
- querying metadata can be done through a global variable to speed up
  multiple queries
- Add generate_task_graph() which is a generic TC graph generator
- Move _query_metadata() from buildbot_bridge module
- Add _recreate_task() to generate a task based on a older one
- Refactor retrigger_task() to also create a graph for the single task
- Fix description in _query_metadata()
- Print link to task graph
- Print graph only in schedule_graph()
- add credentials_available() which determines if the client id and
  token are set as environment variables. This is useful to not fail
  trying to interact with TC
- add handle_auth_failure() to be used by various code paths
- add generic create_task()

platforms.py
^^^^^^^^^^^^
- Better docstring for get_builder_information()

errors.py
^^^^^^^^^
- Sort errors alphabetically
- Add TaskClusterError
