### PR TITLE
Bug 1212004 - Handle when buildapi fails to submit a request

### DIFF
--- a/mozci/sources/buildapi.py
+++ b/mozci/sources/buildapi.py
@@ -44,18 +44,23 @@ def trigger_arbitrary_job(repo_name, builder, revision, files=[], dry_run=False,
         LOG.info("         with this payload: %s" % str(payload))
         return None
 
-    # NOTE: A good response returns json with request_id as one of the keys
-    req = requests.post(
-        url,
-        headers={'Accept': 'application/json'},
-        data=payload,
-        auth=get_credentials()
-    )
-    if req.status_code == 401:
-        remove_credentials()
-        raise AuthenticationError("Your credentials were invalid. Please try again.")
+    try:
+        # NOTE: A good response returns json with request_id as one of the keys
+        req = requests.post(
+            url,
+            headers={'Accept': 'application/json'},
+            data=payload,
+            auth=get_credentials()
+        )
+        if req.status_code == 401:
+            remove_credentials()
+            raise AuthenticationError("Your credentials were invalid. Please try again.")
 
-    content = req.json()
+        content = req.json()
+    except ValueError:
+        LOG.warning("We did not get info from %s (status code: %s)" % (url, req.status_code))
+        return None
+
     LOG.debug("Status of the request: %s" %
               _jobs_api_url(content["request_id"]))
 

--- a/mozci/sources/buildapi.py
+++ b/mozci/sources/buildapi.py
@@ -44,27 +44,25 @@ def trigger_arbitrary_job(repo_name, builder, revision, files=[], dry_run=False,
         LOG.info("         with this payload: %s" % str(payload))
         return None
 
-    try:
-        # NOTE: A good response returns json with request_id as one of the keys
-        req = requests.post(
-            url,
-            headers={'Accept': 'application/json'},
-            data=payload,
-            auth=get_credentials()
-        )
-        if req.status_code == 401:
-            remove_credentials()
-            raise AuthenticationError("Your credentials were invalid. Please try again.")
+    # NOTE: A good response returns json with request_id as one of the keys
+    req = requests.post(
+        url,
+        headers={'Accept': 'application/json'},
+        data=payload,
+        auth=get_credentials()
+    )
+    if req.status_code == 401:
+        remove_credentials()
+        raise AuthenticationError("Your credentials were invalid. Please try again.")
 
+    try:
         content = req.json()
+        LOG.debug("Status of the request: %s" % _jobs_api_url(content["request_id"]))
+        return req
+
     except ValueError:
         LOG.warning("We did not get info from %s (status code: %s)" % (url, req.status_code))
         return None
-
-    LOG.debug("Status of the request: %s" %
-              _jobs_api_url(content["request_id"]))
-
-    return req
 
 
 def make_retrigger_request(repo_name, request_id, count=1, priority=0, dry_run=True):


### PR DESCRIPTION
r?

We could have also added retry logic for now this is good enough (since at least we can recognize the status error).

https://bugzilla.mozilla.org/show_bug.cgi?id=1212004
