### PR TITLE
Major refactoring of platforms.py to improve future development.

### DIFF
--- a/mozci/mozci.py
+++ b/mozci/mozci.py
@@ -15,9 +15,14 @@ from __future__ import absolute_import
 import logging
 
 from mozci.errors import MozciError
-from mozci.platforms import determine_upstream_builder, is_downstream, \
-    filter_buildernames, build_talos_buildernames_for_repo
-from mozci.sources import allthethings, buildapi, buildjson, pushlog
+from mozci.platforms import (
+    build_talos_buildernames_for_repo,
+    determine_upstream_builder,
+    filter_buildernames,
+    is_downstream,
+    list_builders,
+)
+from mozci.sources import buildapi, buildjson, pushlog
 from mozci.query_jobs import (
     PENDING,
     RUNNING,
@@ -261,9 +266,9 @@ def _find_files(job_schedule_info):
 #
 # Query functionality
 #
-def query_builders():
-    """Return list of all builders."""
-    return allthethings.list_builders()
+def query_builders(repo_name=None):
+    """Return list of all builders or the builders associated to a repo."""
+    return list_builders(repo_name)
 
 
 def query_repo_name_from_buildername(buildername, clobber=False):
@@ -490,11 +495,11 @@ def trigger(builder, revision, files=[], dry_run=False, extra_properties=None):
 def trigger_missing_jobs_for_revision(repo_name, revision, dry_run=False):
     """
     Trigger missing jobs for a given revision.
-    Jobs have any of ('hg bundle', 'b2g', 'pgo') in their buildername will not be triggered.
+    Jobs containing 'b2g' or 'pgo' in their buildername will not be triggered.
     """
-    all_buildernames = filter_buildernames([repo_name],
-                                           ['hg bundle', 'b2g', 'pgo'],
-                                           allthethings.list_builders())
+    all_buildernames = filter_buildernames(
+        exclude=['b2g', 'pgo'],
+        builders=list_builders(repo_name=repo_name))
 
     for buildername in all_buildernames:
         trigger_range(buildername=buildername,

--- a/mozci/scripts/misc/write_tests_per_platform_graph.py
+++ b/mozci/scripts/misc/write_tests_per_platform_graph.py
@@ -1,13 +1,12 @@
 """This script writes a mapping from platforms to tests that run in it to graph.json."""
 import json
 
-from mozci.platforms import build_tests_per_platform_graph, _filter_builders_matching
-from mozci.sources.allthethings import fetch_allthethings_data
+from mozci.platforms import build_tests_per_platform_graph, list_builders
 from mozci.utils.transfer import path_to_file
 
 
 if __name__ == '__main__':
     with open(path_to_file('graph.json'), 'w') as f:
-        builders = _filter_builders_matching(fetch_allthethings_data()['builders'], " try ")
-        graph = build_tests_per_platform_graph(builders)
+        graph = build_tests_per_platform_graph(
+            builders=list_builders(repo_name='try'))
         json.dump(graph, f, sort_keys=True, indent=4, separators=(',', ': '))

--- a/mozci/sources/allthethings.py
+++ b/mozci/sources/allthethings.py
@@ -121,7 +121,7 @@ def fetch_allthethings_data(no_caching=False, verify=True):
     return DATA
 
 
-def list_builders():
+def _list_builders():
     """Return a list of all builders running in the buildbot CI."""
     j = fetch_allthethings_data()
     builders_list = j["builders"].keys()

--- a/mozci/sources/buildbot_bridge.py
+++ b/mozci/sources/buildbot_bridge.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 
 from mozci.errors import MozciError
 from mozci.mozci import valid_builder
-from mozci.platforms import get_builder_information
+from mozci.platforms import get_builder_metadata
 from mozci.sources.buildapi import query_repo_url
 from mozci.sources.pushlog import query_revision_info
 from mozci.sources.tc import (
@@ -47,8 +47,8 @@ def _create_task(buildername, repo_name, revision, task_graph_id=None,
     if not valid_builder(buildername):
         raise MozciError("The builder '%s' is not a valid one." % buildername)
 
-    builder_info = get_builder_information(buildername)
-    if builder_info['properties']['branch'] != repo_name:
+    builder_info = get_builder_metadata(buildername)
+    if builder_info['repo_name'] != repo_name:
         raise MozciError(
             "The builder '%s' should be for repo: %s." % (buildername, repo_name)
         )
@@ -72,7 +72,7 @@ def _create_task(buildername, repo_name, revision, task_graph_id=None,
             },
             # Needed because of bug 1195751
             'properties': {
-                'product': builder_info['properties']['product'],
+                'product': builder_info['product'],
                 'who': push_info['user']
             }
         },
@@ -138,7 +138,10 @@ def generate_graph_from_builders(repo_name, revision, buildernames, *args, **kwa
     :rtype: dict
 
     """
-    return generate_builders_tc_graph(repo_name, revision, buildbot_graph_builder(buildernames))
+    return generate_builders_tc_graph(
+        repo_name=repo_name,
+        revision=revision,
+        builders_graph=buildbot_graph_builder(buildernames))
 
 
 def generate_builders_tc_graph(repo_name, revision, builders_graph):

--- a/test/test_allthethings.py
+++ b/test/test_allthethings.py
@@ -112,11 +112,11 @@ class TestFetching(unittest.TestCase):
 
 class TestListBuilders(unittest.TestCase):
 
-    """Test list_builders with mock data."""
+    """Test _list_builders with mock data."""
 
     @patch('mozci.sources.allthethings.fetch_allthethings_data')
-    def test_list_builders_with_mock_data(self, fetch_allthethings_data):
-        """list_builders should return list of builders from allthethings."""
+    def test__list_builders_with_mock_data(self, fetch_allthethings_data):
+        """_list_builders should return list of builders from allthethings."""
         fetch_allthethings_data.return_value = json.loads("""
         {"builders" :
             {
@@ -127,11 +127,11 @@ class TestListBuilders(unittest.TestCase):
 
         expected_sorted = [u'Builder 1', u'Builder 2']
 
-        self.assertEquals(sorted(allthethings.list_builders()), expected_sorted)
+        self.assertEquals(sorted(allthethings._list_builders()), expected_sorted)
 
     @patch('mozci.sources.allthethings.fetch_allthethings_data')
-    def test_list_builders_assert_on_empty_list(self, fetch_allthethings_data):
-        """list_builders should raise AssertionError if there are no builders listed."""
+    def test__list_builders_assert_on_empty_list(self, fetch_allthethings_data):
+        """_list_builders should raise AssertionError if there are no builders listed."""
         fetch_allthethings_data.return_value = json.loads("""
         {
         "builders" : {},
@@ -142,4 +142,4 @@ class TestListBuilders(unittest.TestCase):
             }
         }""")
         with self.assertRaises(AssertionError):
-            allthethings.list_builders()
+            allthethings._list_builders()


### PR DESCRIPTION
## mozci.py
- query_builders() can now handle getting builders of one repo
- trigger_missing_jobs_for_revisions() now uses list_builders() to
  access builders of a repo without using string matching
## platforms.py
- We now discard certain builders with _wanted_builder()
- get_buildername_metadata() gives a curated set of important
- metadata about
  a builder
- _get_test() renamed to _get_suite_name()
- build_tests_per_platform_graph() refactored for readability &
  extensibility
- _include_builders_matching() & _exclude_builders_matching()
- instead of
  _filter_builders_matching()
- refactored find_buildernames for readability
## test_platforms.py
- Changes due to platforms.py function renames
- Clean up of code
- Remove unused patch calls
## buildbot_brdige.py
- Make use of enhanced get_buildername_metadata()
