### PR TITLE
Bug 1214625 - Ignore non pgo talos builders + fix test regressions

### DIFF
--- a/mozci/mozci.py
+++ b/mozci/mozci.py
@@ -18,7 +18,6 @@ from mozci.errors import MozciError
 from mozci.platforms import (
     build_talos_buildernames_for_repo,
     determine_upstream_builder,
-    filter_buildernames,
     is_downstream,
     list_builders,
 )
@@ -497,18 +496,20 @@ def trigger_missing_jobs_for_revision(repo_name, revision, dry_run=False):
     Trigger missing jobs for a given revision.
     Jobs containing 'b2g' or 'pgo' in their buildername will not be triggered.
     """
-    all_buildernames = filter_buildernames(
-        exclude=['b2g', 'pgo'],
-        builders=list_builders(repo_name=repo_name))
+    builders_for_repo = list_builders(repo_name=repo_name)
 
-    for buildername in all_buildernames:
-        trigger_range(buildername=buildername,
-                      revisions=[revision],
-                      times=1,
-                      dry_run=dry_run,
-                      extra_properties={'mozci_request': {
-                                        'type': 'trigger_missing_jobs_for_revision'}
-                                        })
+    for buildername in builders_for_repo:
+        trigger_range(
+            buildername=buildername,
+            revisions=[revision],
+            times=1,
+            dry_run=dry_run,
+            extra_properties={
+                'mozci_request': {
+                    'type': 'trigger_missing_jobs_for_revision'
+                }
+            }
+        )
 
 
 def trigger_all_talos_jobs(repo_name, revision, times, dry_run=False):


### PR DESCRIPTION
When trying to fill in a revision we need to determine the list of
available builders for that repo.

In the case of mozilla-aurora and mozilla-beta, allthethings.json
contains both the pgo and non-pgo builders (Buildbot bug).

There is no parent builder for mozci to trigger and we fail.

This change ignores these builders.

This change also refactors the trigger.py script and adds a
--fill-revision option to test this change.

Read below for changes fixing regressions introduced in
e4b5d8233e0e3ba3afe12c3761a7656221e6afd1
## mozci.py
- For trigger_missing_jobs_for_revision() do not use
  filter_buildernames() (string matching) but list_builders().
  It fixes including invalid talos builders
## platforms.py
- Add job_type and suite_name to get_buildername_metadata()
- Drop _get_suite_name()
- In build_tests_per_platform_graph() fix regression and use
  list_builders() instead of _include_builders_matching() (string
  matching).
- Change signature of filter_buildernames()
- Improve _wanted_builder() logic to differentiate talos builders on
  mozilla-{aurora,beta} properly
- Fix regression in list_builders()
## test_platforms.py
- Clean up + minor refactor
- Drop test_get_suite_name() for TestGetBuildernameMetadata
