### PR TITLE
Bug 1195824 - Improve output of backfilling for Heroku's logging

### DIFF
--- a/mozci/query_jobs.py
+++ b/mozci/query_jobs.py
@@ -1,10 +1,13 @@
+from __future__ import absolute_import
+
 import logging
 
-from errors import TreeherderError, BuildapiError, BuildjsonError
 from abc import ABCMeta, abstractmethod
 from thclient import TreeherderClient
-from sources import buildapi
-from sources.buildjson import query_job_data
+
+from mozci.errors import TreeherderError, BuildapiError, BuildjsonError
+from mozci.sources import buildapi
+from mozci.sources.buildjson import query_job_data
 
 
 LOG = logging.getLogger('mozci')

--- a/mozci/scripts/trigger.py
+++ b/mozci/scripts/trigger.py
@@ -202,10 +202,10 @@ def determine_revlist(repo_url, buildername, rev, back_revisions,
 
     elif backfill:
         revlist = find_backfill_revlist(
-            repo_url=repo_url,
+            buildername=buildername,
             revision=rev,
             max_revisions=max_revisions,
-            buildername=buildername)
+        )
 
     else:
         revlist = [rev]

--- a/mozci/sources/buildapi.py
+++ b/mozci/sources/buildapi.py
@@ -11,18 +11,18 @@ http://moz-releng-buildapi.readthedocs.org
 """
 from __future__ import absolute_import
 import json
+import logging
 import os
 
 import requests
 
 from mozci.errors import BuildapiError, AuthenticationError
 from mozci.utils.authentication import get_credentials, remove_credentials
-from mozci.utils.log_util import setup_logging
 from mozci.utils.transfer import path_to_file
 from mozci.sources import pushlog
 
 HOST_ROOT = 'https://secure.pub.build.mozilla.org/buildapi/self-serve'
-LOG = setup_logging()
+LOG = logging.getLogger('mozci')
 REPOSITORIES_FILE = path_to_file("repositories.txt")
 REPOSITORIES = {}
 

--- a/mozci/utils/authentication.py
+++ b/mozci/utils/authentication.py
@@ -7,13 +7,13 @@
 """Module for http authentication operations."""
 
 import getpass
+import logging
 import os
 
 import keyring
 import requests
 
 from mozci.utils.transfer import path_to_file
-from mozci.utils.log_util import setup_logging
 
 AUTH = None
 CREDENTIALS_PATH = path_to_file("credentials.cfg")
@@ -21,7 +21,7 @@ DIRNAME = os.path.dirname(CREDENTIALS_PATH)
 KEYRING_KEY = 'ldap'
 # We use buildapi since we don't have a better option
 LDAP_HOST = 'https://secure.pub.build.mozilla.org/buildapi/self-serve'
-LOG = setup_logging()
+LOG = logging.getLogger('mozci')
 
 
 def _prompt_password_storing(https_username):

--- a/mozci/utils/log_util.py
+++ b/mozci/utils/log_util.py
@@ -44,8 +44,8 @@ def setup_logging(level=logging.INFO):
     if level != logging.DEBUG:
         # requests is too noisy and adds no value
         logging.getLogger("requests").setLevel(logging.WARNING)
-
-    if level == logging.DEBUG:
+        LOG.info("Setting %s level" % logging.getLevelName(level))
+    else:
         LOG.info("Setting DEBUG level")
 
     return LOG

--- a/mozci/utils/misc.py
+++ b/mozci/utils/misc.py
@@ -2,12 +2,13 @@
 """This module simply adds miscellaneous code that the main modules can use."""
 from __future__ import absolute_import
 
+import logging
+
 import requests
 
 from mozci.utils.authentication import get_credentials
-from mozci.utils.log_util import setup_logging
 
-LOG = setup_logging()
+LOG = logging.getLogger('mozci')
 
 
 def _public_url(url):


### PR DESCRIPTION
## various modules
- Only scripts should use setup_logging() since it sets the level of logging
- Internal modules should use getLogger("mozci")
## mozci.py
- Change few messages from info() to debug()
- Change signature of find_backfill_revlist() to remove the need for repo_url
## query_jobs.py
- Minor refactoring to use absolute imports
