### PR TITLE
Bug 1220141 - Fix triggerbyfilters regression + flake8 issues

### DIFF
--- a/mozci/scripts/triggerbyfilters.py
+++ b/mozci/scripts/triggerbyfilters.py
@@ -93,7 +93,11 @@ def main():
     if options.exclude:
         filters_out = options.exclude.split(',')
 
-    buildernames = filter_buildernames(filters_in, filters_out, query_builders())
+    buildernames = filter_buildernames(
+        buildernames=query_builders(repo_name=options.repo),
+        include=filters_in,
+        exclude=filters_out
+    )
 
     if len(buildernames) == 0:
         LOG.info("0 jobs match these filters, please try again.")

--- a/mozci/utils/transfer.py
+++ b/mozci/utils/transfer.py
@@ -229,7 +229,7 @@ def _lean_load_json_file(filepath):
         # and ignore the rest.
         ret['builds'] = [{
             'properties': {
-                key: value for (key, value) in b["properties"].iteritems() \
+                key: value for (key, value) in b["properties"].iteritems()
                 if key in ('buildername', 'request_ids', 'revision', 'packageUrl',
                            'testPackagesUrl', 'testsUrl')
             },
@@ -243,6 +243,5 @@ def _lean_load_json_file(filepath):
     finally:
         fd.close()
         gzipper.close()
-
 
     return ret


### PR DESCRIPTION
In https://github.com/mozilla/mozilla_ci_tools/commit/21591a35bf84bc2f4b741ce9949b2e6f6c753ba9#diff-080760856cfeb3690166d07dd9636fdfL404
we changed the signature of triggerbyfilters().

Unfortunately we did not change this on triggerbyfilters.py script.

We also fix some missed flake8 issues.
