### PR TITLE
Use the full 20 byte / 40 character hashes for revisions

### DIFF
--- a/mozci/scripts/buildbot_to_taskcluster.py
+++ b/mozci/scripts/buildbot_to_taskcluster.py
@@ -13,6 +13,8 @@ from mozci.platforms import get_downstream_jobs
 from mozci.utils.log_util import setup_logging
 from mozci.sources.buildbot_bridge import trigger_builders_based_on_task_id
 from mozci.sources.tc import credentials_available
+from mozci.sources.buildapi import query_repo_url
+from mozci.sources.pushlog import query_full_revision_info
 
 
 def main():
@@ -78,7 +80,9 @@ def main():
 
     if not options.dry_run and not credentials_available():
         sys.exit(1)
-
+    repo_url = query_repo_url(options.repo_name)
+    revision = query_full_revision_info(repo_url,
+                                        options.revision)
     mgr = TaskClusterBuildbotManager()
     builders = None
     if options.builders:
@@ -89,7 +93,7 @@ def main():
     if options.trigger_from_task_id and builders:
         trigger_builders_based_on_task_id(
             repo_name=options.repo_name,
-            revision=options.revision,
+            revision=revision,
             task_id=options.trigger_from_task_id,
             builders=builders,
             dry_run=options.dry_run
@@ -97,14 +101,14 @@ def main():
     elif builders and len(builders) == 1:
         mgr.schedule_arbitrary_job(
             repo_name=options.repo_name,
-            revision=options.revision,
+            revision=revision,
             uuid=builders[0],
             dry_run=options.dry_run
         )
     elif options.builders_graph:
         mgr.schedule_graph(
             repo_name=options.repo_name,
-            revision=options.revision,
+            revision=revision,
             builders_graph=ast.literal_eval(options.builders_graph),
             dry_run=options.dry_run
         )

--- a/mozci/scripts/misc/find_status_for_jobs.py
+++ b/mozci/scripts/misc/find_status_for_jobs.py
@@ -60,8 +60,8 @@ if __name__ == "__main__":
             print 'https://treeherder.mozilla.org/#/jobs?%s' % \
                 (urllib.urlencode({
                     'repo': repo_name,
-                    'fromchange': schedule_info["revision"][0:12],
-                    'tochange': revision[0:12],
+                    'fromchange': schedule_info["revision"],
+                    'tochange': revision,
                     'filter-searchStr': options.buildername,
                     'filter-resultStatus': ['success', 'testfailed', 'busted',
                                             'exception', 'retry', 'usercancel',

--- a/test/test_pushlog.py
+++ b/test/test_pushlog.py
@@ -4,17 +4,13 @@ import unittest
 from mock import patch, Mock
 from mozci.sources import pushlog
 
-
-def mock_response(content):
-    """Mock of requests.get()."""
-    response = Mock()
-    response.content = content
-
-    def mock_response_json():
-        return json.loads(content)
-
-    response.json = mock_response_json
-    return response
+REVISION_INFO_REPOSITORIES = """{
+    "87833": {
+    "changesets": ["71e69424094d2f86c51ba544fd861d65a578a0f2"],
+     "date": 1441983569,
+     "user": "nobody@mozilla.com"}
+}
+"""
 
 INVALID_REVISION = """
 "unknown revision '123456123456s'"
@@ -31,6 +27,18 @@ GOOD_REVISION = """
  }
 }
 """
+
+
+def mock_response(content):
+    """Mock of requests.get()."""
+    response = Mock()
+    response.content = content
+
+    def mock_response_json():
+        return json.loads(content)
+
+    response.json = mock_response_json
+    return response
 
 
 class TestValidRevision(unittest.TestCase):
@@ -63,3 +71,16 @@ class TestValidRevision(unittest.TestCase):
         """Calling the function with a bad revision."""
         self.assertEquals(
             pushlog.valid_revision("try", "123456123456"), False)
+
+
+class TestRevisionQuery(unittest.TestCase):
+    """Test functions which been used in pushlog query"""
+    def setUp(self):
+        self.repo_url = 'http://hg.mozilla.org/integration/mozilla-inbound'
+
+    @patch('requests.get', return_value=mock_response(REVISION_INFO_REPOSITORIES))
+    def test_query_full_revision_infoo(self, get):
+        self.assertEqual(
+            pushlog.query_full_revision_info(self.repo_url, '71e69424094'),
+            '71e69424094d2f86c51ba544fd861d65a578a0f2'
+        )


### PR DESCRIPTION
 we use 40 chars revision rather than 12 chars in **query_jobs.py**  and  **pushlog.py**. And we can accept 12-char in **buildbot_to_taskcluster.py** then find its 40-char representation in it.
