### PR TITLE
Issue 384 - Make trigger.py to schedule jobs through TaskCluster instead of Buildapi

### DIFF
--- a/mozci/mozci.py
+++ b/mozci/mozci.py
@@ -438,10 +438,10 @@ def trigger_job(revision, buildername, times=1, files=None, dry_run=False,
     return list_of_requests
 
 
-def trigger_range(buildername, revisions, times=1, dry_run=False,
+def trigger_range(buildername, repo_name, revisions, times=1, dry_run=False,
                   files=None, extra_properties=None, trigger_build_if_missing=True):
     """Schedule the job named "buildername" ("times" times) in every revision on 'revisions'."""
-    repo_name = query_repo_name_from_buildername(buildername)
+    assert repo_name in buildername
     repo_url = repositories.query_repo_url(repo_name)
 
     if revisions != []:

--- a/mozci/sources/tc.py
+++ b/mozci/sources/tc.py
@@ -66,8 +66,8 @@ def generate_metadata(repo_name, revision, name,
     :type description: str
     """
     repo_url = query_repo_url(repo_name)
-    push_info = push_info = query_push_by_revision(repo_url=repo_url,
-                                                   revision=revision)
+    push_info = query_push_by_revision(repo_url=repo_url,
+                                       revision=revision)
 
     return {
         'name': name,


### PR DESCRIPTION
It's PR for https://github.com/mozilla/mozilla_ci_tools/issues/384, But it's not good to go yet.

The ideal of this PR is:

> get build_graph
> if schedule_way == "taskCluster"(which is default):
>    trigger_job(option.uuid)
> else:
>    use buildapi(just like we used before)
