### PR TITLE
Setup logging immediately after parsing args

### DIFF
--- a/mozci/scripts/trigger.py
+++ b/mozci/scripts/trigger.py
@@ -233,16 +233,16 @@ def determine_revlist(repo_url, buildername, rev, back_revisions,
 
 def main():
     options = parse_args()
+    if options.debug:
+        LOG = setup_logging(logging.DEBUG)
+    else:
+        LOG = setup_logging(logging.INFO)
+
     validate_options(options)
     repo_url = query_repo_url(options.repo_name)
 
     if not valid_credentials():
         sys.exit(-1)
-
-    if options.debug:
-        LOG = setup_logging(logging.DEBUG)
-    else:
-        LOG = setup_logging(logging.INFO)
 
     # Setting the QUERY_SOURCE global variable in mozci.py
     set_query_source(options.query_source)

--- a/mozci/scripts/triggerbyfilters.py
+++ b/mozci/scripts/triggerbyfilters.py
@@ -81,14 +81,14 @@ def parse_args(argv=None):
 
 def main():
     options = parse_args()
-    repo_url = query_repo_url(options.repo)
-    if not valid_credentials():
-        sys.exit(-1)
-
     if options.debug:
         LOG = setup_logging(logging.DEBUG)
     else:
         LOG = setup_logging(logging.INFO)
+
+    repo_url = query_repo_url(options.repo)
+    if not valid_credentials():
+        sys.exit(-1)
 
     if options.rev == 'tip':
         revision = query_repo_tip(repo_url)


### PR DESCRIPTION
The function `query_repo_url` also produces some log which shouldn't be missed. Logging should be set up immediately after parsing args, otherwise there is a chance we miss something.
