### PR TITLE
Update treeherder-client dependency from >=1.4 to >=2.0.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(
         'progressbar>=2.3',
         'requests>=2.5.1',
         'taskcluster>=0.0.28',
-        'treeherder-client>=1.4'
+        'treeherder-client>=2.0.1'
     ],
 
     # Meta-data for upload to PyPI

--- a/setup.py
+++ b/setup.py
@@ -28,5 +28,5 @@ setup(
                  Mozilla's Buildbot CI (and TaskCluster in the future). \
                  It simplifies and unifies querying and triggering jobs.",
     license='MPL',
-    url='http://github.com/mozilla/mozilla_ci_tools',
+    url='https://github.com/mozilla/mozilla_ci_tools',
 )


### PR DESCRIPTION
To ensure consumers of mozci don't use deprecated versions of TreeherderClient if they are re-using virtualenvs.

Notably 2.0.1 includes an API URL fix that will prevent 404s once non-canonical URLs are disabled in bug 1234233.
