### PR TITLE
Upgrade requests to the latest release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'keyring>=5.3',
         'progressbar>=2.3',
         'pushlog_client>=0.3',
-        'requests>=2.5.1',
+        'requests>=2.8.1',
         'taskcluster>=0.0.28',
         'treeherder-client>=2.0.1',
     ],


### PR DESCRIPTION
I upgrade my requests to 2.8.1(actually the latest one is 2.9.1) and test is. It seems like we don't need to change any code about it :)
