### PR TITLE
Make the project flake8_docstrings compatible

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -10,6 +10,7 @@ deps =
     flake8
     pytest
     mock
+    flake8_docstrings
 
 commands =
     flake8 mozci test
@@ -19,3 +20,4 @@ commands =
 exclude = .tox
 show-source = True
 max-line-length=100
+ignore=D100,D101,D102,D103,D104,D105,D200,D201,D202,D203,D204,D205,D208,D210,D211,D300,D400,D401,E123


### PR DESCRIPTION
Hi armenzg,

Works fine on my system. feel free to test it on your system.This change is to enable flake8_docstrings for tox and also supress warnings that you see after that when you run tox in venv.

r? armenzg

Regards,
Tapesh Mandal
IRC nick: tapesh
email: tapesh.mandal@gmail.com
