### PR TITLE
re-trigger all orange jobs for a particular revision

### DIFF
--- a/mozci/query_jobs.py
+++ b/mozci/query_jobs.py
@@ -296,3 +296,17 @@ class TreeherderApi(QueryApi):
 
         LOG.debug(job)
         raise TreeherderError("Unexpected status")
+
+    def find_all_jobs_by_status(self, repo_name, revision, status):
+        builder_names = []
+        jobs = self.get_all_jobs(repo_name, revision)
+        # filer out those jobs without builder name
+        jobs = [job for job in jobs if job['machine_name'] != 'unknown']
+        for job in jobs:
+            try:
+                job_status = self.get_job_status(job)
+            except TreeherderError:
+                continue
+            if job_status == status:
+                builder_names.append(job['ref_data_name'])
+        return builder_names


### PR DESCRIPTION
Here is what I got by: (mozicitool_env)MikeLings-MacBook-Pro-2:mozilla_ci_tools mikeling$ python mozci/scripts/trigger.py --revision a1e682c00ff3 --repo-name try --failed-jobs

> 02/10/2016 11:08:54 root INFO:  Setting INFO level
> [u'Linux x86-64 try leak test build', u'Ubuntu VM 12.04 x64 try debug test mochitest-2', u'Ubuntu VM 12.04 x64 try debug test mochitest-4']
> 02/10/2016 11:09:02 root INFO:  https://treeherder.mozilla.org/#/jobs?repo=try&revision=a1e682c00ff34c054a1217a8f057038cc8f8ffbb
> 02/10/2016 11:09:02 mozci INFO: We want to have 1 job(s) of Linux x86-64 try leak test build on the following revisions: 
> 02/10/2016 11:09:02 mozci INFO:  - a1e682c00ff34c054a1217a8f057038cc8f8ffbb
> 02/10/2016 11:09:02 mozci INFO: 
> 02/10/2016 11:09:02 mozci INFO: === a1e682c00ff34c054a1217a8f057038cc8f8ffbb ===
> 02/10/2016 11:09:04 mozci INFO: We want to have 1 job(s) of Linux x86-64 try leak test build
> 02/10/2016 11:09:14 mozci INFO: We have 1 job(s) for 'Linux x86-64 try leak test build' which is enough for the 1 job(s) we want.
> 02/10/2016 11:09:14 root INFO:  https://treeherder.mozilla.org/#/jobs?repo=try&revision=a1e682c00ff34c054a1217a8f057038cc8f8ffbb
> 02/10/2016 11:09:14 mozci INFO: We want to have 1 job(s) of Ubuntu VM 12.04 x64 try debug test mochitest-2 on the following revisions: 
> 02/10/2016 11:09:14 mozci INFO:  - a1e682c00ff34c054a1217a8f057038cc8f8ffbb
> 02/10/2016 11:09:14 mozci INFO: 
> 02/10/2016 11:09:14 mozci INFO: === a1e682c00ff34c054a1217a8f057038cc8f8ffbb ===
> 02/10/2016 11:09:14 mozci INFO: We want to have 1 job(s) of Ubuntu VM 12.04 x64 try debug test mochitest-2
> 02/10/2016 11:09:14 mozci INFO: We have 2 job(s) for 'Ubuntu VM 12.04 x64 try debug test mochitest-2' which is enough for the 1 job(s) we want.
> 02/10/2016 11:09:14 root INFO:  https://treeherder.mozilla.org/#/jobs?repo=try&revision=a1e682c00ff34c054a1217a8f057038cc8f8ffbb
> 02/10/2016 11:09:14 mozci INFO: We want to have 1 job(s) of Ubuntu VM 12.04 x64 try debug test mochitest-4 on the following revisions: 
> 02/10/2016 11:09:14 mozci INFO:  - a1e682c00ff34c054a1217a8f057038cc8f8ffbb
> 02/10/2016 11:09:14 mozci INFO: 
> 02/10/2016 11:09:14 mozci INFO: === a1e682c00ff34c054a1217a8f057038cc8f8ffbb ===
> 02/10/2016 11:09:14 mozci INFO: We want to have 1 job(s) of Ubuntu VM 12.04 x64 try debug test mochitest-4
> 02/10/2016 11:09:24 mozci INFO: We have 1 job(s) for 'Ubuntu VM 12.04 x64 try debug test mochitest-4' which is enough for the 1 job(s) we want.
