### PR TITLE
Indicate the buildername when submitting a BBB task instead of 'pulse…

### DIFF
--- a/mozci/sources/buildbot_bridge.py
+++ b/mozci/sources/buildbot_bridge.py
@@ -100,6 +100,10 @@ def _create_task(buildername, repo_name, revision, metadata=None, task_graph_id=
                           revision=revision,
                           name=buildername)
 
+    # The task's name is used in the task-graph-inspector to list all tasks
+    # and using the buildername makes it easy for a person to recognize each job.
+    metadata['name'] = buildername
+
     # XXX: We should validate that the parent task is a valid parent platform
     #      e.g. do not schedule Windows tests against Linux builds
     task = create_task(

--- a/test/test_buildbot_bridge.py
+++ b/test/test_buildbot_bridge.py
@@ -1,0 +1,28 @@
+"""This file contains tests for mozci/sources/buildbot_bridge.py."""
+import unittest
+from mozci.sources import buildbot_bridge
+
+
+class TestBuildbotBridge(unittest.TestCase):
+    """Test that buildbot bridge is correctly scheduling tasks"""
+    def setUp(self):
+        self.buildernames = ['Android armv7 API 15+ try debug build']
+        self.revision = '1ab622ac1706a0f5dfaf7734a1c56aa9d3502eec'
+        self.repo_name = 'try'
+        self.builders_graph, _ = buildbot_bridge.buildbot_graph_builder(
+            builders=self.buildernames,
+            revision=self.revision,
+            complete=False
+        )
+
+    def test_task_name_metadata_is_buildername(self):
+        self.graph = buildbot_bridge.generate_builders_tc_graph(
+            self.repo_name,
+            self.revision,
+            self.builders_graph
+        )
+        flag = False
+        for task in self.graph['tasks']:
+            if task['task']['metadata']['name'] == self.buildernames[0]:
+                flag = True
+        self.assertEquals(flag, True)


### PR DESCRIPTION
…_actions_graph'
It locally passes `tox`
ref #444
