### PR TITLE
Speed up buildbot_bridge.py test + add logging to tests

### DIFF
--- a/mozci/sources/buildbot_bridge.py
+++ b/mozci/sources/buildbot_bridge.py
@@ -390,8 +390,10 @@ def generate_builders_tc_graph(repo_name, revision, builders_graph, *args, **kwa
     :rtype: dict
 
     """
+    LOG.debug("Generating TaskCluster BBB graph...")
     if builders_graph is None:
         return None
+
     metadata = kwargs.get('metadata')
     if metadata is None:
         metadata = generate_metadata(repo_name=repo_name,

--- a/mozci/sources/tc.py
+++ b/mozci/sources/tc.py
@@ -78,6 +78,7 @@ def generate_metadata(repo_name, revision, name,
     :param description: Human readable description of task-graph, explain what it does!
     :type description: str
     """
+    LOG.debug("Determining metadata.")
     repo_url = query_repo_url(repo_name)
     push_info = query_push_by_revision(repo_url=repo_url,
                                        revision=revision)

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -1,0 +1,24 @@
+''' Auxiliary module to help load mock_allthethings.json for all tests. '''
+import logging
+import json
+import os
+
+from mozci.utils.log_util import setup_logging
+
+
+def _get_mock_allthethings():
+    """Load a mock allthethings.json from disk."""
+    PATH = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)),
+        "mock_allthethings.json"
+    )
+    with open(PATH, 'r') as f:
+        return json.load(f)
+
+
+def debug_logging():
+    ''' Call this from a test and you will then be able to call py.test with -s'''
+    setup_logging(logging.DEBUG)
+
+
+MOCK_ALLTHETHINGS = _get_mock_allthethings()

--- a/test/mock_allthethings.json
+++ b/test/mock_allthethings.json
@@ -1,7 +1,7 @@
 {"builders": {
-    "Platform1 repo opt test mochitest-1": {
+    "Platform1 try opt test mochitest-1": {
         "properties": {
-            "branch": "repo",
+            "branch": "try",
             "platform": "platform1",
             "product": "real-product",
             "repo_path": "real-path",
@@ -13,9 +13,9 @@
         "slavebuilddir": "test",
         "slavepool": "b23a27e728808b811f86a8a7a20edb1b3648ec9a"
     },
-    "Platform1 repo pgo test mochitest-1": {
+    "Platform1 try pgo test mochitest-1": {
         "properties": {
-            "branch": "repo",
+            "branch": "try",
             "platform": "platform1",
             "product": "real-product",
             "repo_path": "real-path",
@@ -27,9 +27,9 @@
         "slavebuilddir": "test",
         "slavepool": "b23a27e728808b811f86a8a7a20edb1b3648ec9a"
     },
-    "Platform1 repo debug test mochitest-1": {
+    "Platform1 try debug test mochitest-1": {
         "properties": {
-            "branch": "repo",
+            "branch": "try",
             "platform": "platform1",
             "product": "real-product",
             "repo_path": "real-path",
@@ -41,9 +41,9 @@
         "slavebuilddir": "test",
         "slavepool": "b23a27e728808b811f86a8a7a20edb1b3648ec9a"
     },
-    "Platform1 repo talos tp5o": {
+    "Platform1 try talos tp5o": {
         "properties": {
-            "branch": "repo",
+            "branch": "try",
             "platform": "platform1",
             "product": "real-product",
             "repo_path": "real-path",
@@ -97,15 +97,15 @@
         "slavebuilddir": "test",
         "slavepool": "b23a27e728808b811f86a8a7a20edb1b3648ec9a"
     },
-    "Platform1 repo build": {
+    "Platform1 try build": {
         "properties": {
-            "branch": "repo",
+            "branch": "try",
             "platform": "platform1",
             "product": "real-product",
             "slavebuilddir": "branch-platform-00000000000000000",
             "stage_platform": "real-platform"
         },
-        "shortname": "repo-platform",
+        "shortname": "try-platform",
         "slavebuilddir": "branch-platform-00000000000000000",
         "slavepool": "2e490369b232e800931337b9b1186f5027eac1e6"
     },
@@ -301,42 +301,42 @@
         "slavebuilddir": "branch-platform-00000000000000000",
         "slavepool": "2e490369b232e800931337b9b1186f5027eac1e6"
     },
-    "Platform1 repo leak test build": {
+    "Platform1 try leak test build": {
         "properties": {
-            "branch": "repo",
+            "branch": "try",
             "platform": "platform1-debug",
             "product": "real-product",
             "slavebuilddir": "branch-platform-00000000000000000",
             "stage_platform": "real-platform"
         },
-        "shortname": "repo-platform-debug",
+        "shortname": "try-platform-debug",
         "slavebuilddir": "branch-platform-00000000000000000",
         "slavepool": "2e490369b232e800931337b9b1186f5027eac1e6"
     }
     },
  "schedulers": {
-     "tests-repo-platform-unittest": {
+     "tests-try-platform-unittest": {
          "downstream": [
-             "Platform1 repo opt test mochitest-1"
+             "Platform1 try opt test mochitest-1"
          ],
          "triggered_by": [
-             "repo-platform-opt-unittest"
+             "try-platform-opt-unittest"
          ]
      },
-     "tests-repo-platform-debug-unittest": {
+     "tests-try-platform-debug-unittest": {
          "downstream": [
-             "Platform1 repo debug test mochitest-1"
+             "Platform1 try debug test mochitest-1"
          ],
          "triggered_by": [
-             "repo-platform-debug-unittest"
+             "try-platform-debug-unittest"
          ]
      },
-     "tests-repo-platform-talos": {
+     "tests-try-platform-talos": {
          "downstream": [
-             "Platform1 repo talos tp5o"
+             "Platform1 try talos tp5o"
          ],
          "triggered_by": [
-             "repo-platform-talos"
+             "try-platform-talos"
          ]
      },
      "tests-mozilla-beta-platform1-talos": {

--- a/test/test_buildbot_bridge.py
+++ b/test/test_buildbot_bridge.py
@@ -1,28 +1,62 @@
 """This file contains tests for mozci/sources/buildbot_bridge.py."""
 import unittest
-from mozci.sources import buildbot_bridge
+
+from mock import Mock, patch
+
+from mozci.sources.buildbot_bridge import (
+    _create_task,
+)
+
+from helpers import (
+    MOCK_ALLTHETHINGS,
+    debug_logging
+)
+
+debug_logging()
 
 
 class TestBuildbotBridge(unittest.TestCase):
     """Test that buildbot bridge is correctly scheduling tasks"""
     def setUp(self):
-        self.buildernames = ['Android armv7 API 15+ try debug build']
         self.revision = '1ab622ac1706a0f5dfaf7734a1c56aa9d3502eec'
         self.repo_name = 'try'
-        self.builders_graph, _ = buildbot_bridge.buildbot_graph_builder(
-            builders=self.buildernames,
-            revision=self.revision,
-            complete=False
-        )
+        self.repo_url = 'https://hg.mozilla.org/try'
 
-    def test_task_name_metadata_is_buildername(self):
-        self.graph = buildbot_bridge.generate_builders_tc_graph(
-            self.repo_name,
-            self.revision,
-            self.builders_graph
+        node = Mock()
+        node.node = u'1ab622ac1706a0f5dfaf7734a1c56aa9d3502eec'
+
+        self.push_info = Mock()
+        self.push_info.changesets = [node]
+
+    @patch('mozci.platforms.fetch_allthethings_data', return_value=MOCK_ALLTHETHINGS)
+    @patch('mozci.sources.buildbot_bridge.query_push_by_revision')
+    @patch('mozci.sources.buildbot_bridge.query_repo_url')
+    @patch('mozci.sources.buildbot_bridge.valid_builder', return_value=True)
+    def test_task_name_metadata_is_buildername(self,
+                                               valid_builder,
+                                               query_repo_url,
+                                               query_push_by_revision,
+                                               fetch_allthethings_data):
+        ''' We want to test that the builder will show up in the metadata of a created task.
+
+        This helps when we look at tasks when inspecting a graph scheduled via BBB.
+        See https://github.com/mozilla/mozilla_ci_tools/issues/444 for details.
+        '''
+        query_push_by_revision.return_value = self.push_info
+        query_repo_url.return_value = self.repo_url
+
+        builder = 'Platform1 try leak test build'
+        metadata = {
+            'owner': u'dminor@mozilla.com',
+            'source': u'https://hg.mozilla.org/try/rev/1ab622ac1706a0f5dfaf7734a1c56aa9d3502eec',
+            'name': builder,
+            'description': 'Task graph generated via Mozilla CI tools'
+        }
+
+        task = _create_task(
+            buildername=builder,
+            repo_name=self.repo_name,
+            revision=self.revision,
+            metadata=metadata,
         )
-        flag = False
-        for task in self.graph['tasks']:
-            if task['task']['metadata']['name'] == self.buildernames[0]:
-                flag = True
-        self.assertEquals(flag, True)
+        self.assertEquals(task['task']['metadata']['name'], builder)

--- a/test/test_platforms.py
+++ b/test/test_platforms.py
@@ -48,9 +48,9 @@ class TestIsDownstream(unittest.TestCase):
         """is_downstream should return True for test jobs and False for build jobs."""
         fetch_allthethings_data.return_value = MOCK_ALLTHETHINGS
         self.assertEquals(
-            is_downstream('Platform1 repo opt test mochitest-1'), True)
+            is_downstream('Platform1 try opt test mochitest-1'), True)
         self.assertEquals(
-            is_downstream('Platform1 repo build'), False)
+            is_downstream('Platform1 try build'), False)
 
     @patch('mozci.platforms.fetch_allthethings_data')
     def test_invalid(self, fetch_allthethings_data):
@@ -68,16 +68,16 @@ class TestFindBuildernames(unittest.TestCase):
         """The function should return a list with the specific buildername."""
         fetch_allthethings_data.return_value = MOCK_ALLTHETHINGS
         self.assertEquals(
-            find_buildernames('repo', 'mochitest-1', 'platform1', 'opt'),
-            ['Platform1 repo opt test mochitest-1'])
+            find_buildernames('try', 'mochitest-1', 'platform1', 'opt'),
+            ['Platform1 try opt test mochitest-1'])
 
     @patch('mozci.platforms.fetch_allthethings_data')
     def test_with_debug(self, fetch_allthethings_data):
         """The function should return a list with the specific debug buildername."""
         fetch_allthethings_data.return_value = MOCK_ALLTHETHINGS
         self.assertEquals(
-            find_buildernames('repo', 'mochitest-1', 'platform1', 'debug'),
-            ['Platform1 repo debug test mochitest-1'])
+            find_buildernames('try', 'mochitest-1', 'platform1', 'debug'),
+            ['Platform1 try debug test mochitest-1'])
 
     @patch('mozci.platforms.fetch_allthethings_data')
     def test_without_platform(self, fetch_allthethings_data):
@@ -104,7 +104,7 @@ class TestFindBuildernames(unittest.TestCase):
     def test_invalid(self):
         """The function should raise an error if both platform and test are None."""
         with pytest.raises(AssertionError):
-            find_buildernames('repo', suite_name=None, platform=None)
+            find_buildernames('try', suite_name=None, platform=None)
 
 
 class TestFilterBuildernames(unittest.TestCase):
@@ -116,11 +116,11 @@ class TestFilterBuildernames(unittest.TestCase):
         buildernames = MOCK_ALLTHETHINGS['builders'].keys()
         self.assertEquals(
             filter_buildernames(
-                include=['repo', 'mochitest-1'],
+                include=['try', 'mochitest-1'],
                 exclude=['debug', 'pgo'],
                 buildernames=buildernames
             ),
-            ['Platform1 repo opt test mochitest-1']
+            ['Platform1 try opt test mochitest-1']
         )
 
 
@@ -170,7 +170,7 @@ class TestGetPlatform(unittest.TestCase):
         """For non-talos test jobs it should return the platform attribute."""
         fetch_allthethings_data.return_value = MOCK_ALLTHETHINGS
         self.assertEquals(
-            get_associated_platform_name('Platform1 repo opt test mochitest-1'),
+            get_associated_platform_name('Platform1 try opt test mochitest-1'),
             'platform1')
 
     @patch('mozci.platforms.fetch_allthethings_data')
@@ -178,7 +178,7 @@ class TestGetPlatform(unittest.TestCase):
         """For talos jobs it should return the stage-platform attribute."""
         fetch_allthethings_data.return_value = MOCK_ALLTHETHINGS
         self.assertEquals(
-            get_associated_platform_name('Platform1 repo talos tp5o'),
+            get_associated_platform_name('Platform1 try talos tp5o'),
             'stage-platform1')
 
     @patch('mozci.platforms.fetch_allthethings_data')
@@ -186,7 +186,7 @@ class TestGetPlatform(unittest.TestCase):
         """For build jobs it should return the platform attribute."""
         fetch_allthethings_data.return_value = MOCK_ALLTHETHINGS
         self.assertEquals(
-            get_associated_platform_name('Platform1 repo build'),
+            get_associated_platform_name('Platform1 try build'),
             'platform1')
 
 
@@ -220,7 +220,7 @@ class TestWantedBuilder(unittest.TestCase):
             _wanted_builder('Platform1 mozilla-esr45 pgo test mochitest-1'),
             True)
         self.assertEquals(
-            _wanted_builder('Platform1 repo pgo test mochitest-1'),
+            _wanted_builder('Platform1 try pgo test mochitest-1'),
             False)
         with pytest.raises(MozciError):
             _wanted_builder('Platform1 non-existent-repo1 pgo test mochitest-1')
@@ -251,7 +251,7 @@ class TestWantedBuilder(unittest.TestCase):
             _wanted_builder('Platform1 mozilla-esr45 opt test mochitest-1'),
             True)
         self.assertEquals(
-            _wanted_builder('Platform1 repo opt test mochitest-1'),
+            _wanted_builder('Platform1 try opt test mochitest-1'),
             True)
         with pytest.raises(MozciError):
             _wanted_builder('Platform1 non-existent-repo2 opt test mochitest-1')
@@ -265,22 +265,22 @@ class TestBuildGraph(unittest.TestCase):
     def test_build_graph(self, fetch_allthethings_data):
         """Test if the graph has the correct format."""
         fetch_allthethings_data.return_value = MOCK_ALLTHETHINGS
-        builders = list_builders(repo_name='repo')
+        builders = list_builders(repo_name='try')
         builders.sort()
         expected = {
             'debug': {
                 'platform1': {
                     'tests': ['mochitest-1'],
-                    'Platform1 repo leak test build': [
-                        'Platform1 repo debug test mochitest-1']
+                    'Platform1 try leak test build': [
+                        'Platform1 try debug test mochitest-1']
                 }
             },
             'opt': {
                 'platform1': {
                     'tests': ['mochitest-1', 'tp5o'],
-                    'Platform1 repo build': [
-                        'Platform1 repo opt test mochitest-1',
-                        'Platform1 repo talos tp5o']
+                    'Platform1 try build': [
+                        'Platform1 try opt test mochitest-1',
+                        'Platform1 try talos tp5o']
                 }
             }
         }
@@ -297,11 +297,11 @@ class TestDetermineUpstream(unittest.TestCase):
         """Test if the function finds the right builder."""
         fetch_allthethings_data.return_value = MOCK_ALLTHETHINGS
         self.assertEquals(
-            determine_upstream_builder('Platform1 repo opt test mochitest-1'),
-            'Platform1 repo build')
+            determine_upstream_builder('Platform1 try opt test mochitest-1'),
+            'Platform1 try build')
         self.assertEquals(
-            determine_upstream_builder('Platform1 repo debug test mochitest-1'),
-            'Platform1 repo leak test build')
+            determine_upstream_builder('Platform1 try debug test mochitest-1'),
+            'Platform1 try leak test build')
         self.assertEquals(
             determine_upstream_builder('Platform1 mozilla-beta pgo talos tp5o'),
             'Platform1 mozilla-beta build')
@@ -333,10 +333,10 @@ class TestGetDownstream(unittest.TestCase):
         """Test if the function finds the right downstream jobs."""
         fetch_allthethings_data.return_value = MOCK_ALLTHETHINGS
         self.assertEquals(
-            sorted(get_downstream_jobs('Platform1 repo build')),
+            sorted(get_downstream_jobs('Platform1 try build')),
             [
-                'Platform1 repo opt test mochitest-1',
-                'Platform1 repo talos tp5o'
+                'Platform1 try opt test mochitest-1',
+                'Platform1 try talos tp5o'
             ])
 
 
@@ -370,8 +370,8 @@ class TestGetBuildernameMetadata(unittest.TestCase):
         """Test if the function finds the right suite_name."""
         fetch_allthethings_data.return_value = MOCK_ALLTHETHINGS
         test_cases = [
-            ("Platform1 repo talos tp5o", "tp5o"),
-            ("Platform1 repo opt test mochitest-1", "mochitest-1")
+            ("Platform1 try talos tp5o", "tp5o"),
+            ("Platform1 try opt test mochitest-1", "mochitest-1")
         ]
         for t in test_cases:
             self.assertEquals(get_buildername_metadata(t[0])['suite_name'], t[1])
@@ -388,10 +388,10 @@ def test_include_builders_matching():
 
 
 get_job_type_test_cases = [
-    ("Platform1 repo pgo talos mochitest-1", "pgo"),
-    ("Platform1 repo debug test mochitest-1", "debug"),
-    ("Platform2 repo talos tp5o", "opt"),
-    ("Platform1 repo opt test mochitest-1", "opt")]
+    ("Platform1 try pgo talos mochitest-1", "pgo"),
+    ("Platform1 try debug test mochitest-1", "debug"),
+    ("Platform2 try talos tp5o", "opt"),
+    ("Platform1 try opt test mochitest-1", "opt")]
 
 
 @pytest.mark.parametrize("test_job, expected", get_job_type_test_cases)

--- a/test/test_tc.py
+++ b/test/test_tc.py
@@ -1,37 +1,93 @@
 """This file contains the tests for mozci/sources/tc.py"""
-import unittest
 import json
+import unittest
 import os
+
+# 3rd party modules
 from jsonschema.exceptions import ValidationError
-from mozci.sources import tc
+from mock import Mock, patch
 
-json_file = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                         "tc_test_graph.json")
-json_file2 = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                          "tc_test_graph2.json")
-json_file3 = os.path.join(os.path.dirname(os.path.abspath(__file__)),
-                          "tc_test_graph3.json")
+# Current tool
+from mozci.sources.tc import (
+    generate_metadata,
+    validate_graph
+)
+from helpers import (
+    debug_logging
+)
+
+debug_logging()
+CWD = os.path.dirname(os.path.abspath(__file__))
 
 
-class TestTaskCluster(unittest.TestCase):
+class TestTaskClusterGraphs(unittest.TestCase):
     """Testing mozci integration with TaskCluster"""
     def setUp(self):
-        with open(json_file) as data_file:
-            self.data = json.load(data_file)
-        with open(json_file2) as data_file:
-            self.data2 = json.load(data_file)
-        with open(json_file3) as data_file:
-            self.data3 = json.load(data_file)
+        with open(os.path.join(CWD, 'tc_test_graph.json')) as data_file:
+            self.bad_graph = json.load(data_file)
+
+        with open(os.path.join(CWD, 'tc_test_graph2.json')) as data_file:
+            self.bad_graph_2 = json.load(data_file)
+
+        with open(os.path.join(CWD, 'tc_test_graph3.json')) as data_file:
+            self.good_graph = json.load(data_file)
 
     def test_check_invalid_graph(self):
         # This file lacks the "task" property under "tasks"
-        self.assertRaises(ValidationError, tc.validate_graph, self.data)
+        self.assertRaises(ValidationError, validate_graph, self.bad_graph)
 
     def test_check_invalid_graph2(self):
         # This should fail as the owner's email ID is not valid
-        self.assertRaises(ValidationError, tc.validate_graph, self.data2)
+        self.assertRaises(ValidationError, validate_graph, self.bad_graph_2)
 
     def test_check_valid_graph(self):
         # Similar to the previous test, but with the correct owner field
-        tc.validate_graph(self.data3)
+        validate_graph(self.good_graph)
         self.assert_(True)
+
+
+class TestTaskGeneration(unittest.TestCase):
+    """Test that we can create tasks with expected values."""
+
+    def setUp(self):
+        self.revision = '1ab622ac1706a0f5dfaf7734a1c56aa9d3502eec'
+        self.repo_name = 'try'
+        self.repo_url = 'https://hg.mozilla.org/try'
+
+        # Let's mock what Push object looks like
+        node = Mock()
+        node.node = u'1ab622ac1706a0f5dfaf7734a1c56aa9d3502eec'
+
+        self.push_info = Mock()
+        self.push_info.user = u'dminor@mozilla.com'
+        self.push_info.changesets = [node]
+
+    @patch('mozci.sources.tc.query_push_by_revision')
+    @patch('mozci.sources.tc.query_repo_url')
+    def test_metadata_contains_matches_name(self,
+                                            query_repo_url,
+                                            query_push_by_revision):
+        ''' We want to test that the builder will show up in the name of the metadata.
+
+        This helps when we look at tasks when inspecting a graph scheduled via BBB.
+        See https://github.com/mozilla/mozilla_ci_tools/issues/444 for details.
+        '''
+        query_repo_url.return_value = self.repo_url
+        query_push_by_revision.return_value = self.push_info
+
+        builder = 'Platform1 try leak test build'
+        metadata = {
+            'name': builder,
+            'description': 'Task graph generated via Mozilla CI tools',
+            'owner': self.push_info.user,
+            'source': u'%s/rev/%s' % (self.repo_url, self.revision)
+        }
+
+        self.assertEquals(
+            generate_metadata(
+                repo_name=self.repo_name,
+                revision=self.revision,
+                name=builder
+            ),
+            metadata
+        )


### PR DESCRIPTION
The original test for buildbot_bridge did not completely mock everything
that it should. That caused the test to take over 10 seconds to run. In
order to speed this up I narrowed down the test to the creation of a
task and the appropriate setting of the metadata for it (original test
case).

We've also added a test module called helpers.py which allows tests to
easily activate adding debug messages. Doing this helps a lot when using
py.test with the -s flag (do not capture stdout). This helps when trying
to determine if functions are properly patched or not.

I've also renamed all tests making reference to a 'repo' repo name and
instead I'm using 'try' to make string matching easier.  I guess I could
have used 'mock-repo'.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/mozilla_ci_tools/454)

<!-- Reviewable:end -->
