### PR TITLE
Fix TaskClusterManager web authentication + other improvements

### DIFF
--- a/mozci/taskcluster/tc.py
+++ b/mozci/taskcluster/tc.py
@@ -75,12 +75,12 @@ class TaskClusterManager(BaseCIManager):
 
         :param task: It is a TaskCluster task.
         :type task: json
-        :param update_timestamps:
-            It will not update the timestamps if False.
+        :param update_timestamps: It will not update the timestamps if False.
         :type update_timestamps: bool
-        :param dry_run:
-            It allows overwriting the dry_run mode at creation of the manager.
+        :param dry_run: It allows overwriting the dry_run mode at creation of the manager.
         :type dry_run: bool
+        :returns: Task Status Structure (see link to createTask documentation)
+        :rtype: dict
 
         """
         LOG.debug("We want to schedule a TC task")


### PR DESCRIPTION
We were not instantiating TaskCluster's Queue() properly since we had to
call it as {'credentials': credentials}.

The conditions to use the various authentication approaches was also
bogus.

We added web_auth to the class in order that we can control when to use
web authentication.

We've also fixed schedule_task() to return a Task Status Structure
instead of nothing.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/mozilla_ci_tools/467)

<!-- Reviewable:end -->
