### PR TITLE
Bug 1289823 - Flexible action task

### DIFF
--- a/mozci/taskcluster/tc.py
+++ b/mozci/taskcluster/tc.py
@@ -114,7 +114,7 @@ class TaskClusterManager(BaseCIManager):
 
         # Satisfying mustache template variables in YML file
         # We must account for both the old and new style of arg passing
-        if action_args:
+        if action_args and "{{action_args}}" in action_task:
             action_args = " ".join(["--{}='{}'".format(k, v) for k, v in action_args.items()])
             action_task = action_task.replace("{{action_args}}", action_args)
         else:

--- a/mozci/taskcluster/tc.py
+++ b/mozci/taskcluster/tc.py
@@ -102,7 +102,7 @@ class TaskClusterManager(BaseCIManager):
         else:
             LOG.info("We did not schedule anything because we're running on dry run mode.")
 
-    def schedule_action_task(self, decision_task_id=None, task_labels=None, action_args=None):
+    def schedule_action_task(self, decision_task_id, task_labels=None, action_args=None):
         """
         Function which will be used to schedule an action task.
         Action Tasks use in-tree logic to schedule the task_labels

--- a/mozci/taskcluster/tc.py
+++ b/mozci/taskcluster/tc.py
@@ -102,7 +102,7 @@ class TaskClusterManager(BaseCIManager):
         else:
             LOG.info("We did not schedule anything because we're running on dry run mode.")
 
-    def schedule_action_task(self, decision_task_id, task_labels):
+    def schedule_action_task(self, decision_task_id=None, task_labels=None, action_args=None):
         """
         Function which will be used to schedule an action task.
         Action Tasks use in-tree logic to schedule the task_labels
@@ -113,8 +113,13 @@ class TaskClusterManager(BaseCIManager):
                                                artifact_path="public/action.yml")
 
         # Satisfying mustache template variables in YML file
-        action_task = action_task.replace("{{decision_task_id}}", decision_task_id)
-        action_task = action_task.replace("{{task_labels}}", ",".join(task_labels))
+        # We must account for both the old and new style of arg passing
+        if action_args:
+            action_args = " ".join(["--{}='{}'".format(k, v) for k, v in action_args.items()])
+            action_task = action_task.replace("{{action_args}}", action_args)
+        else:
+            action_task = action_task.replace("{{decision_task_id}}", decision_task_id)
+            action_task = action_task.replace("{{task_labels}}", ",".join(task_labels))
 
         task = yaml.load(action_task)
         text = json.dumps(task, indent=4, sort_keys=True)

--- a/test/helpers.py
+++ b/test/helpers.py
@@ -32,8 +32,11 @@ def _get_graph_result():
     with open(PATH, 'r') as f:
         return json.load(f)
 
+
 ALLTHETHINGS = _get_allthethings()
 
+
 SETA_RESULT = _get_SETA()
+
 
 GRAPH_RESULT = _get_graph_result()


### PR DESCRIPTION
@armenzg: This should be updated here and pulled into pulse_actions before https://reviewboard.mozilla.org/r/96072 lands. It will allow it to work with both styles of action.yml until the old-style is completely gone at some point. I have backfill logic in-tree ready to go once this is all merged in if this is a good direction to go in.

Heads up: @djmitche

The added lines in `test/helpers.py` was just to get `tox` to pass locally. I assume some lint library was updated at some point or something.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/mozilla_ci_tools/504)
<!-- Reviewable:end -->
