### PR TITLE
Fix single-quotes in yaml template

### DIFF
--- a/test/taskcluster/good_action.yml
+++ b/test/taskcluster/good_action.yml
@@ -1,0 +1,52 @@
+created: '2016-12-13T02:44:51.234559Z'
+deadline: '2016-12-14T02:44:51.235856Z'
+expires: '2016-12-27T02:44:51.235929Z'
+extra:
+  treeherder:
+    symbol: A
+metadata:
+  description: Helps schedule new jobs without new push
+  name: '[tc] Action Task'
+  owner: mozilla-taskcluster-maintenance@mozilla.com
+  source: https://hg.mozilla.org/try/file/7b0f8cbd55495620bf40e0a2610008091e58bed0/taskcluster/taskgraph/action.yml
+payload:
+  artifacts:
+    public:
+      expires: '2016-12-20T02:44:51.236106Z'
+      path: /home/worker/artifacts
+      type: directory
+  cache:
+    level-1-checkouts: /home/worker/checkouts
+  command:
+  - /home/worker/bin/run-task
+  - --vcs-checkout=/home/worker/checkouts/gecko
+  - --
+  - bash
+  - -cx
+  - 'cd /home/worker/checkouts/gecko && ln -s /home/worker/artifacts artifacts &&
+    ./mach --log-no-times taskgraph {{action}} {{action_args}}
+
+    '
+  env:
+    GECKO_BASE_REPOSITORY: https://hg.mozilla.org/mozilla-unified
+    GECKO_HEAD_REF: 7b0f8cbd55495620bf40e0a2610008091e58bed0
+    GECKO_HEAD_REPOSITORY: https://hg.mozilla.org/try/
+    GECKO_HEAD_REV: 7b0f8cbd55495620bf40e0a2610008091e58bed0
+    HG_STORE_PATH: /home/worker/checkouts/hg-store
+  features:
+    taskclusterProxy: true
+  image: taskcluster/decision:0.1.7
+  maxRunTime: 1800
+provisionerId: aws-provisioner-v1
+routes:
+- tc-treeherder.v2.try.7b0f8cbd55495620bf40e0a2610008091e58bed0.158891
+- tc-treeherder-stage.v2.try.7b0f8cbd55495620bf40e0a2610008091e58bed0.158891
+schedulerId: gecko-level-1
+scopes:
+- docker-worker:cache:level-1-*
+- docker-worker:cache:tooltool-cache
+- secrets:get:project/taskcluster/gecko/hgfingerprint
+- assume:repo:hg.mozilla.org/try:*
+tags:
+  createdForUser: bstack@mozilla.com
+workerType: gecko-decision

--- a/test/taskcluster/good_action_old_style.yml
+++ b/test/taskcluster/good_action_old_style.yml
@@ -1,0 +1,53 @@
+created: '2016-12-13T02:44:51.234559Z'
+deadline: '2016-12-14T02:44:51.235856Z'
+expires: '2016-12-27T02:44:51.235929Z'
+extra:
+  treeherder:
+    symbol: A
+metadata:
+  description: Helps schedule new jobs without new push
+  name: '[tc] Action Task'
+  owner: mozilla-taskcluster-maintenance@mozilla.com
+  source: https://hg.mozilla.org/try/file/7b0f8cbd55495620bf40e0a2610008091e58bed0/taskcluster/taskgraph/action.yml
+payload:
+  artifacts:
+    public:
+      expires: '2016-12-20T02:44:51.236106Z'
+      path: /home/worker/artifacts
+      type: directory
+  cache:
+    level-1-checkouts: /home/worker/checkouts
+  command:
+  - /home/worker/bin/run-task
+  - --vcs-checkout=/home/worker/checkouts/gecko
+  - --
+  - bash
+  - -cx
+  - 'cd /home/worker/checkouts/gecko && ln -s /home/worker/artifacts artifacts &&
+    ./mach --log-no-times taskgraph action-task --decision-id=''{{decision_task_id}}''
+        --task-label=''{{task_labels}}''
+
+    '
+  env:
+    GECKO_BASE_REPOSITORY: https://hg.mozilla.org/mozilla-unified
+    GECKO_HEAD_REF: 7b0f8cbd55495620bf40e0a2610008091e58bed0
+    GECKO_HEAD_REPOSITORY: https://hg.mozilla.org/try/
+    GECKO_HEAD_REV: 7b0f8cbd55495620bf40e0a2610008091e58bed0
+    HG_STORE_PATH: /home/worker/checkouts/hg-store
+  features:
+    taskclusterProxy: true
+  image: taskcluster/decision:0.1.7
+  maxRunTime: 1800
+provisionerId: aws-provisioner-v1
+routes:
+- tc-treeherder.v2.try.7b0f8cbd55495620bf40e0a2610008091e58bed0.158891
+- tc-treeherder-stage.v2.try.7b0f8cbd55495620bf40e0a2610008091e58bed0.158891
+schedulerId: gecko-level-1
+scopes:
+- docker-worker:cache:level-1-*
+- docker-worker:cache:tooltool-cache
+- secrets:get:project/taskcluster/gecko/hgfingerprint
+- assume:repo:hg.mozilla.org/try:*
+tags:
+  createdForUser: bstack@mozilla.com
+workerType: gecko-decision

--- a/test/taskcluster/test_taskcluster.py
+++ b/test/taskcluster/test_taskcluster.py
@@ -10,6 +10,7 @@ from mock import Mock, patch
 
 # Current tool
 from mozci.taskcluster import (
+    TaskClusterManager,
     TC_SCHEMA_URL,
     credentials_available,
     generate_metadata,
@@ -40,6 +41,23 @@ def good_graph1():
         return json.load(data_file)
 
 
+@pytest.fixture
+def tc_manager():
+    return TaskClusterManager(dry_run=True)
+
+
+@pytest.fixture
+def good_action_old_style():
+    with open(os.path.join(CWD, 'good_action_old_style.yml')) as data_file:
+        return data_file.read()
+
+
+@pytest.fixture
+def good_action():
+    with open(os.path.join(CWD, 'good_action.yml')) as data_file:
+        return data_file.read()
+
+
 #
 # Beginning of tests
 #
@@ -63,6 +81,27 @@ class TestTaskClusterGraphs():
     def test_check_valid_graph(self, good_graph1):
         # Similar to the previous test, but with the correct owner field
         validate_schema(instance=good_graph1, schema_url=TC_SCHEMA_URL)
+
+
+class TestTaskClusterActionTask():
+    def test_check_valid_action(self, tc_manager, good_action):
+        task = json.loads(tc_manager.render_action_task(
+            good_action,
+            'action-task',
+            'abc123',
+            {'foo_bar': 'baz'}
+        ))
+        assert 'taskgraph action-task --foo-bar="baz"' in task['payload']['command'][-1]
+
+    def test_check_valid_action_old_style(self, tc_manager, good_action_old_style):
+        task = json.loads(tc_manager.render_action_task(
+            good_action_old_style,
+            'action-task',
+            'abc123',
+            {'task_labels': ['baz/bar']}
+        ))
+        assert ("taskgraph action-task --decision-id='abc123' --task-label='baz/bar'" in
+                task['payload']['command'][-1])
 
 
 class TestTaskGeneration(unittest.TestCase):

--- a/test/taskcluster/test_taskcluster.py
+++ b/test/taskcluster/test_taskcluster.py
@@ -10,8 +10,8 @@ from mock import Mock, patch
 
 # Current tool
 from mozci.taskcluster import (
-    TaskClusterManager,
     TC_SCHEMA_URL,
+    TaskClusterManager,
     credentials_available,
     generate_metadata,
     validate_schema,


### PR DESCRIPTION
@armenzg: sorry, this needs changed one more time. The single quotes wrapping the variables were getting inserted into something that was already getting rendered with single quotes around it so it was breaking yaml rendering. I've added tests for this section now though, so we should not have to change this again!

The change of `decision_task_id` to `decision_id` was made to match this to the in-tree `action.py` more closely without requiring us to do special-casing in this code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/mozilla_ci_tools/506)
<!-- Reviewable:end -->
