### PR TITLE
Fix one more inconsistency between action implementations

### DIFF
--- a/mozci/taskcluster/tc.py
+++ b/mozci/taskcluster/tc.py
@@ -121,12 +121,10 @@ class TaskClusterManager(BaseCIManager):
             action_args = [(k.replace('_', '-'), v) for k, v in action_args.items()]
             action_args = ['--{}="{}"'.format(k, v) for k, v in action_args]
             action_task = action_task.replace("{{action}}", action)
-            action_task = action_task.replace("{{action_args}}", " ".join(action_args))
+            action_task = action_task.replace("{{action_args}}", " ".join(sorted(action_args)))
         else:
             action_task = action_task.replace("{{decision_task_id}}", decision_id)
-            action_task = action_task.replace("{{task_labels}}", ",".join(
-                action_args["task_labels"])
-            )
+            action_task = action_task.replace("{{task_labels}}", action_args["task_labels"])
 
         task = yaml.load(action_task)
         text = json.dumps(task, indent=4, sort_keys=True)

--- a/test/taskcluster/test_taskcluster.py
+++ b/test/taskcluster/test_taskcluster.py
@@ -89,16 +89,17 @@ class TestTaskClusterActionTask():
             good_action,
             'action-task',
             'abc123',
-            {'foo_bar': 'baz'}
+            {'decision_id': 'abc123', 'task_label': ','.join([u'abc/123', u'qed/456'])}
         ))
-        assert 'taskgraph action-task --foo-bar="baz"' in task['payload']['command'][-1]
+        assert ('taskgraph action-task --decision-id="abc123" --task-label="abc/123,qed/456"' in
+                task['payload']['command'][-1])
 
     def test_check_valid_action_old_style(self, tc_manager, good_action_old_style):
         task = json.loads(tc_manager.render_action_task(
             good_action_old_style,
             'action-task',
             'abc123',
-            {'task_labels': ['baz/bar']}
+            {'task_labels': ','.join(['baz/bar'])}
         ))
         assert ("taskgraph action-task --decision-id='abc123' --task-label='baz/bar'" in
                 task['payload']['command'][-1])


### PR DESCRIPTION
@armenzg: Sorry, I don't know why I'm messing this up so much. This is one more inconsistency to clean up. I'm going to submit a PR for `pulse_actions` as well, assuming that this change will be released as `0.54.0`. 

This fixes an issue where the new-style wants a collection of strings as values, and the old style can have specific logic to turn lists into strings, etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/mozilla_ci_tools/507)
<!-- Reviewable:end -->
