### PR TITLE
bump the tc version number to 4.0.0 on tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -25,7 +25,7 @@ deps =
     PyYAML==3.11
     requests==2.8.1
     taskcluster==0.3.0
-    treeherder-client==2.0.1
+    treeherder-client==4.0.0
     jsonschema==2.5.1
 
 


### PR DESCRIPTION
Hi @armenzg , 

So after I set up my env by `python setup.py ` and `run tox`, I got this error https://pastebin.mozilla.org/9031957. It seems like the tox require treeherder-client 2.0.1 but the latest number is 4.0.0. I'm not sure if it's a bug, but after I change the version number to 4.0.0, everything works well.

Please close this pr if I misunderstand something.  Thank you.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/mozilla_ci_tools/513)
<!-- Reviewable:end -->
